### PR TITLE
Quickupload: Limit simultaneous uploads to 1 (sequential) to avoid DB conflicts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.2.7 (unreleased)
 ------------------
 
+- Quickupload: Limit simultaneous uploads to 1 (sequential) to avoid DB conflicts
+  [lgraf]
+
 - Prevent default in js-action for ViewChooser-links.
   [Julian Infanger]
 

--- a/ftw/tabbedview/configure.zcml
+++ b/ftw/tabbedview/configure.zcml
@@ -42,6 +42,14 @@
              provides="ftw.dictstorage.interfaces.IConfig"/>
     <adapter factory=".statestorage.DefaultDictStorage" />
 
+    <!-- Register the import_various step -->
+    <genericsetup:importStep
+        name="ftw.tabbedview.various"
+        title="ftw.tabbedview various import steps"
+        description=""
+        handler="ftw.tabbedview.setuphandlers.import_various">
+    </genericsetup:importStep>
+
     <!-- extjs is optional -->
     <configure zcml:condition="installed collective.js.extjs">
         <include package="collective.js.extjs" />

--- a/ftw/tabbedview/profiles/default/ftw.tabbedview_default.txt
+++ b/ftw/tabbedview/profiles/default/ftw.tabbedview_default.txt
@@ -1,0 +1,1 @@
+marker file

--- a/ftw/tabbedview/profiles/extjs/ftw.tabbedview_extjs.txt
+++ b/ftw/tabbedview/profiles/extjs/ftw.tabbedview_extjs.txt
@@ -1,0 +1,1 @@
+marker file

--- a/ftw/tabbedview/profiles/quickupload/ftw.tabbedview_quickupload.txt
+++ b/ftw/tabbedview/profiles/quickupload/ftw.tabbedview_quickupload.txt
@@ -1,0 +1,1 @@
+marker file

--- a/ftw/tabbedview/setuphandlers.py
+++ b/ftw/tabbedview/setuphandlers.py
@@ -1,0 +1,23 @@
+def set_quickupload_settings(portal):
+    from collective.quickupload.browser.quickupload_settings import IQuickUploadControlPanel
+    settings = IQuickUploadControlPanel(portal)
+    # Limit simultaneous uploads to 1 (sequential) to avoid DB conflicts
+    settings.sim_upload_limit = 1
+
+
+def import_various(context):
+    """Import step for configuration that is not handled in xml files.
+    """
+    site = context.getSite()
+
+    # profile-ftw.tabbedview:default
+    if context.readDataFile('ftw.tabbedview_default.txt'):
+        pass
+
+    # profile-ftw.tabbedview:quickupload
+    if context.readDataFile('ftw.tabbedview_quickupload.txt'):
+        set_quickupload_settings(site)
+
+    # profile-ftw.tabbedview:extjs
+    if context.readDataFile('ftw.tabbedview_extjs.txt'):
+        pass


### PR DESCRIPTION
Implementation: Added setuphandlers.py with a function set_quickupload_settings() that's only executed if the ftw.tabbedview:quickupload profile is imported.
