### PR TITLE
Min-height in Tabbedview-body

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.2.7 (unreleased)
 ------------------
 
+- Added min_height to tabbedview-body. Grey-out the tabbedview-body while loading a new tab.
+  [Julian Infanger]
+
 - Fix default tab key storage, so that it includes the user id.
   [jone]
 

--- a/ftw/tabbedview/browser/resources/tabbedview.css
+++ b/ftw/tabbedview/browser/resources/tabbedview.css
@@ -49,3 +49,10 @@
 .tabbdview-tab-menu-template {
   display: none;
 }
+
+#tabbedview-body {
+  min-height: 300px;
+}
+.loading_tab #tabbedview-body {
+  opacity: 0.5;
+}


### PR DESCRIPTION
Added min_height to tabbedview-body. Grey-out the tabbedview-body while loading a new tab.
