### PR TITLE
Basic support for using the tabbed view anonymously.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 3.3.2 (unreleased)
 ------------------
 
+- Basic support for using the tabbed view anonymously.
+  ExtJS is not supported and automatically disabled for anonymous users.
+  [jone]
+
 - Adjust javscripts: Use $ instead of deprecated jq.
   [phgross]
 

--- a/ftw/tabbedview/browser/config.py
+++ b/ftw/tabbedview/browser/config.py
@@ -1,6 +1,7 @@
 from Products.Five.browser import BrowserView
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+import AccessControl
 
 
 class TabbedviewConfigView(BrowserView):
@@ -8,6 +9,14 @@ class TabbedviewConfigView(BrowserView):
     def extjs_enabled(self):
         """Returns `True` if extjs is enabled.
         """
+
+        user = AccessControl.getSecurityManager().getUser()
+        if user == AccessControl.SpecialUsers.nobody:
+            # ExtJS is not supported for anonymous users, since we are not
+            # able to store the state. Things such as sorting would not even
+            # work in the session.
+            return False
+
         registry = getUtility(IRegistry)
         return registry['ftw.tabbedview.interfaces.'
                         'ITabbedView.extjs_enabled']

--- a/ftw/tabbedview/browser/listing.py
+++ b/ftw/tabbedview/browser/listing.py
@@ -16,6 +16,8 @@ from zope.app.pagetemplate import ViewPageTemplateFile
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility, getUtility, getMultiAdapter
 from zope.interface import implements
+import AccessControl
+
 
 try:
     import json
@@ -79,6 +81,9 @@ class ListingView(BrowserView, BaseTableSourceConfig):
             'ftw.tabbedview.interfaces.ITabbedView.max_dynamic_batchsize']
 
     def __call__(self, *args, **kwargs):
+        config_view = self.context.restrictedTraverse('@@tabbedview_config')
+        self.extjs_enabled = config_view.extjs_enabled()
+
         # XXX : we need to be able to detect a extjs update request and return
         # only the template without data, because a later request will update
         # the table with json.

--- a/ftw/tabbedview/browser/tabbed.pt
+++ b/ftw/tabbedview/browser/tabbed.pt
@@ -54,7 +54,8 @@
 
         <div class="visualClear" ></div>
         <div id="tabbedview-body" class="panes">
-            <dl class="actionMenu tabbedview-tab-menu">
+            <dl class="actionMenu tabbedview-tab-menu"
+                tal:condition="view/user_is_logged_in">
                 <dt class="actionMenuHeader">
                     <a href="#">
                         <span>⚙</span>

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -32,6 +32,10 @@ class TabbedView(BrowserView):
 
     __call__ = ViewPageTemplateFile("tabbed.pt")
 
+    def user_is_logged_in(self):
+        user = AccessControl.getSecurityManager().getUser()
+        return user != AccessControl.SpecialUsers.nobody
+
     def get_tabs(self):
         """Returns a list of dicts containing the tabs definitions"""
         for action, icon in self.get_actions(category='tabbedview-tabs'):
@@ -56,8 +60,7 @@ class TabbedView(BrowserView):
         use in the tabbed template.
         """
 
-        user = AccessControl.getSecurityManager().getUser()
-        if user == AccessControl.SpecialUsers.nobody:
+        if not self.user_is_logged_in():
             default_tab = ''
 
         else:
@@ -165,6 +168,9 @@ class TabbedView(BrowserView):
         column order, grouping, sorting etc.) persistent in dictstorage.
         """
 
+        if not self.user_is_logged_in():
+            return
+
         # extract the data
         state = self.request.get('gridstate', None)
         if not state or not isinstance(state, str):
@@ -214,6 +220,10 @@ class TabbedView(BrowserView):
         if ITabbedviewUploadable.providedBy(self.context):
             member = getToolByName(
                 self.context, 'portal_membership').getAuthenticatedMember()
+
+            if not member or member == AccessControl.SpecialUsers.nobody:
+                return False
+
             if member.checkPermission(
                 'Add portal content', self.context):
 

--- a/ftw/tabbedview/statestorage.py
+++ b/ftw/tabbedview/statestorage.py
@@ -9,6 +9,7 @@ from zope.annotation import IAnnotations
 from zope.component import adapts
 from zope.interface import implements
 from zope.publisher.interfaces.browser import IBrowserView
+import AccessControl
 
 
 class DefaultGridStateStorageKeyGenerator(object):
@@ -40,6 +41,9 @@ class DefaultGridStateStorageKeyGenerator(object):
         # add the userid
         mtool = getToolByName(self.context, 'portal_membership')
         member = mtool.getAuthenticatedMember()
+        if not member or member == AccessControl.getSecurityManager().getUser():
+            return None
+
         key.append(member.getId())
 
         # concatenate with "-"


### PR DESCRIPTION
ExtJS is not supported and automatically disabled for anonymous users.
The tabbed view menu is disabled.
File uploads (drag'n'drop) are disabled.

@maethu could you take a look at it?
cc @bbuehlmann 
