### PR TITLE
Plone 4.3: batching

### DIFF
--- a/ftw/tabbedview/browser/listing.py
+++ b/ftw/tabbedview/browser/listing.py
@@ -9,7 +9,6 @@ from ftw.table.basesource import BaseTableSourceConfig
 from ftw.table.catalog_source import DefaultCatalogTableSourceConfig
 from ftw.table.interfaces import ITableGenerator
 from ftw.table.interfaces import ITableSource
-from plone.app.content.batching import Batch
 from plone.memoize import instance
 from plone.registry.interfaces import IRegistry
 from zope.app.pagetemplate import ViewPageTemplateFile
@@ -17,6 +16,12 @@ from zope.component import queryMultiAdapter
 from zope.component import queryUtility, getUtility, getMultiAdapter
 from zope.interface import implements
 
+try:
+    # plone >= 4.3
+    from plone.batching import Batch
+except ImportError:
+    # plone < 4.3
+    from plone.app.content.batching import Batch
 
 try:
     import json

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ extras_require = {
     'tests': tests_require,
     'extjs': ['ftw.table[extjs]'],
     'quickupload': ['collective.quickupload'],
+    'plone4.3': [
+        'plone.batching',
+        ]
     }
 
 setup(name='ftw.tabbedview',


### PR DESCRIPTION
Batch was moved from plone.app.content to plone.batching without deprecation.
Therefore we need to have a fallback for being multi-version compatible.
