### PR TITLE
Fixed markup in tabbedview buttons and added a class to identify buttons.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.3.6 (unreleased)
 ------------------
 
+- Fixed markup in tabbedview buttons and added a class to identify buttons.
+  [Julian Infanger]
+
 - Mark tabbedview header with disabledSearchBox class if the searchbox is disabled.
   [Julian Infanger]
 

--- a/ftw/tabbedview/browser/menu.pt
+++ b/ftw/tabbedview/browser/menu.pt
@@ -4,15 +4,15 @@
     <ul class="tabbedview-action-list">
         <tal:major_buttons tal:repeat="button view/major_buttons">
             <li>
-                <a class="actionicon" href="#" tal:attributes="href button/url;" tal:content="button/title" />
+                <a class="actionicon button" href="#" tal:attributes="href button/url;" tal:content="button/title" />
             </li>
         </tal:major_buttons>
         <li tal:condition="view/minor_buttons">
             <dl id="plone-contentmenu-tabbedview-actions" class="actionMenu deactivated">
               <dt class="actionMenuHeader label-">
-                <a href="">
-                  <span i18n:translate="button_more_actions"
-                    class="arrowDownAlternative">More actions &#9660;</span>
+                <a href="#" class="button">
+                  <span i18n:translate="button_more_actions">More actions</span>
+                  <span class="arrowDownAlternative">&#9660;</span>
                 </a>
               </dt>
               <dd class="actionMenuContent">

--- a/ftw/tabbedview/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2013-01-12 18:37+0000\n"
+"POT-Creation-Date: 2013-06-12 07:25+0000\n"
 "PO-Revision-Date: 2011-12-16 10:48+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -31,12 +31,12 @@ msgstr "Zeilen pro Seite:"
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr "Setzt das aktuelle Tab als Standard-Tab dieser Ansicht. Diese Einstellung ist persönlich."
 
-#: ./ftw/tabbedview/browser/listing.py:503
+#: ./ftw/tabbedview/browser/listing.py:519
 #: ./ftw/tabbedview/profiles/extjs/actions.xml
 msgid "Reset table configuration"
 msgstr "Tabellenkonfiguration zurücksetzen"
 
-#: ./ftw/tabbedview/browser/listing.py:505
+#: ./ftw/tabbedview/browser/listing.py:521
 msgid "Resets the table configuration for this tab."
 msgstr "Konfiguration der Tabelle dieses Tabs auf den Standard zurücksetzen."
 
@@ -51,10 +51,10 @@ msgstr "Titel"
 msgid "all (${amount})"
 msgstr "Alle (${amount})"
 
-#. Default: "More actions &#9660;"
+#. Default: "More actions"
 #: ./ftw/tabbedview/browser/menu.pt:14
 msgid "button_more_actions"
-msgstr "Weitere Aktionen &#9660;"
+msgstr "Weitere Aktionen"
 
 msgid "end"
 msgstr "Ende"

--- a/ftw/tabbedview/locales/en/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/en/LC_MESSAGES/ftw.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2012-07-24 08:29+0000\n"
+"POT-Creation-Date: 2013-06-12 07:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,20 +23,24 @@ msgstr "Select"
 msgid "Creator"
 msgstr "Creator"
 
-#: ./ftw/tabbedview/browser/tabbed.py:87
+#: ./ftw/tabbedview/browser/batching.pt:68
+msgid "Lines per page:"
+msgstr ""
+
+#: ./ftw/tabbedview/browser/tabbed.py:95
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 
-#: ./ftw/tabbedview/browser/listing.py:498
+#: ./ftw/tabbedview/browser/listing.py:519
 #: ./ftw/tabbedview/profiles/extjs/actions.xml
 msgid "Reset table configuration"
 msgstr "Reset table configuration"
 
-#: ./ftw/tabbedview/browser/listing.py:500
+#: ./ftw/tabbedview/browser/listing.py:521
 msgid "Resets the table configuration for this tab."
 msgstr "Resets the table configuration for this tab."
 
-#: ./ftw/tabbedview/browser/tabbed.py:85
+#: ./ftw/tabbedview/browser/tabbed.py:93
 msgid "Set tab as default"
 msgstr "Set tab as default"
 
@@ -47,16 +51,16 @@ msgstr "Title"
 msgid "all (${amount})"
 msgstr "all (${amount})"
 
-#. Default: "More actions &#9660;"
+#. Default: "More actions"
 #: ./ftw/tabbedview/browser/menu.pt:14
 msgid "button_more_actions"
-msgstr "More actions &#9660;"
+msgstr "More actions"
 
 msgid "end"
 msgstr "End"
 
 #. Default: "Could not set default tab."
-#: ./ftw/tabbedview/browser/tabbed.py:236
+#: ./ftw/tabbedview/browser/tabbed.py:257
 msgid "error_set_default_tab"
 msgstr "Could not set default tab."
 
@@ -68,7 +72,7 @@ msgid "hours"
 msgstr "Hours"
 
 #. Default: "The tab ${title} is now your default tab. This is a personal setting."
-#: ./ftw/tabbedview/browser/tabbed.py:244
+#: ./ftw/tabbedview/browser/tabbed.py:265
 msgid "info_set_default_tab"
 msgstr "The tab ${title} is now your default tab. This is a personal setting."
 

--- a/ftw/tabbedview/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-01-12 18:37+0000\n"
+"POT-Creation-Date: 2013-06-12 07:25+0000\n"
 "PO-Revision-Date: 2012-09-10 10:03+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,12 +31,12 @@ msgstr "Lignes par page :"
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr "Faire de l'onglet actuel l'onglet par défaut quand on ouvre cette vue. Ceci est un réglage personnel qui n'a aucun impact pour les autres utilisateurs."
 
-#: ./ftw/tabbedview/browser/listing.py:503
+#: ./ftw/tabbedview/browser/listing.py:519
 #: ./ftw/tabbedview/profiles/extjs/actions.xml
 msgid "Reset table configuration"
 msgstr "Remettre la configuration par défaut des colonnes"
 
-#: ./ftw/tabbedview/browser/listing.py:505
+#: ./ftw/tabbedview/browser/listing.py:521
 msgid "Resets the table configuration for this tab."
 msgstr "Réinitialiser la table de configuration pour cet onglet."
 
@@ -51,7 +51,7 @@ msgstr "Titre"
 msgid "all (${amount})"
 msgstr "Tous"
 
-#. Default: "More actions &#9660;"
+#. Default: "More actions"
 #: ./ftw/tabbedview/browser/menu.pt:14
 msgid "button_more_actions"
 msgstr "Actions supplémentaires"
@@ -100,5 +100,3 @@ msgstr "Début"
 
 msgid "state"
 msgstr "Etat"
-
-

--- a/ftw/tabbedview/locales/ftw.tabbedview.pot
+++ b/ftw/tabbedview/locales/ftw.tabbedview.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-01-12 18:37+0000\n"
+"POT-Creation-Date: 2013-06-12 07:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,12 +36,12 @@ msgstr ""
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr ""
 
-#: ./ftw/tabbedview/browser/listing.py:503
+#: ./ftw/tabbedview/browser/listing.py:519
 #: ./ftw/tabbedview/profiles/extjs/actions.xml
 msgid "Reset table configuration"
 msgstr ""
 
-#: ./ftw/tabbedview/browser/listing.py:505
+#: ./ftw/tabbedview/browser/listing.py:521
 msgid "Resets the table configuration for this tab."
 msgstr ""
 
@@ -56,7 +56,7 @@ msgstr ""
 msgid "all (${amount})"
 msgstr ""
 
-#. Default: "More actions &#9660;"
+#. Default: "More actions"
 #: ./ftw/tabbedview/browser/menu.pt:14
 msgid "button_more_actions"
 msgstr ""


### PR DESCRIPTION
@maethu 
- Fixed markup in tabbedview buttons
  - So the `▼` can have a smaller font-size than the text
- Added a class to identify buttons
  - So there is no problem styling the aciton title as button, but the link in action body as links. 
