### PR TITLE
Fix bug sometimes the default-tab setting did not work.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.3.9 (unreleased)
 ------------------
 
+- Fix bug sometimes the default-tab setting did not work.
+  [jone]
+
 - Fixed not closed script tags.
   [lknoepfel]
 

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -306,6 +306,25 @@ load_tabbedview = function(callback) {
     initialIndex = initial.parents(':first').index();
   }
 
+  /* When a default-tab is configured and we load the tabbedview,
+     the jquerytools history triggers a reload event because the
+     location.hash is changed from empty string to the name of the
+     default tab.
+     Now two tabs are loaded: the first tab of the view and the
+     configured default-tab. Depending on events-timing and load
+     duration the user may be switched to the first tab instead of
+     the default tab he configured.
+     The fix is to terminate events from jquerytools history regarding
+     tab reloading as long as we have no location.hash. This condition
+     makes using browser-back / -forward work because in this situation
+     we have a location.hash. */
+  $('.tabbedview-tabs .formTabs a').on('history', function(e) {
+    if (!location.hash) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  });
+
   $('.tabbedview-tabs').tabs(
     '.panes > div.pane', {
         current:'selected',


### PR DESCRIPTION
The bug is in combination with jquerytools-tab and jquerytools-history,
which caused the history plugin to trigger a tab reload when the default
tab was loaded because the location.hash was changed.

This behavior resulted in two tabs beeing loaded, the default tab and the
first tab of the view with incosistent behavior which of those tabs was
visible at the end.

The fix is here to terminate history events early as long as no actual
hash is in the URL, which is the case when intially loading the tabbed view.
When tabs are klicked the hash is added to the URL, which makes the history
events no longer beeing terminated and enables the default history behavior,
which is that the browser-back and -forward buttons cause the tabs beeing
reloaded correctly.

@maethu can you take a look at this one?
/cc @lukasgraf 
