### PR TITLE
Use live() instead of on() to restore jQuery < 1.7 compatibility.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.3.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use bind() instead of on() to restore jQuery < 1.7 compatibility.
+  [lgraf]
 
 
 3.3.9 (2014-03-28)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -318,7 +318,7 @@ load_tabbedview = function(callback) {
      tab reloading as long as we have no location.hash. This condition
      makes using browser-back / -forward work because in this situation
      we have a location.hash. */
-  $('.tabbedview-tabs .formTabs a').on('history', function(e) {
+  $('.tabbedview-tabs .formTabs a').bind('history', function(e) {
     if (!location.hash) {
       e.preventDefault();
       e.stopPropagation();


### PR DESCRIPTION
The bugfix introduced in 4cd7e08 uses `$().on()`, which only exists in jQuery >= 1.7.

Since Plone 4.2 only ships with jQuery 1.4.4, this effectively broke Plone 4.2 compatibility. In this PR I replace the use of `on()` with `live()` in order to restore compatibility with jQuery 1.7.
