### PR TITLE
Made TabbedView title customizable by a custom tabbedview template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.3.10 (unreleased)
 -------------------
 
+- Made TabbedView title customizable by a custom tabbedview template.
+  [phgross]
+
 - Replaced old spinner image.
   [Julian Infanger]
 

--- a/ftw/tabbedview/browser/tabbed.pt
+++ b/ftw/tabbedview/browser/tabbed.pt
@@ -1,3 +1,4 @@
+<metal:page define-macro="master">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
@@ -43,9 +44,11 @@
           <div tal:replace="structure provider:plone.abovecontenttitle" />
 
 
-          <h1 class="documentFirstHeading">
-            <tal:title replace="context/Title" />
-          </h1>
+          <metal:title define-slot="content-title">
+            <h1 class="documentFirstHeading">
+              <tal:title replace="context/Title" />
+            </h1>
+          </metal:title>
           <div tal:replace="structure provider:plone.belowcontenttitle" />
           <div class="tabbedview-tabs">
             <ul class="formTabs">
@@ -122,3 +125,4 @@
     </div>
   </body>
 </html>
+</metal:page>

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -31,6 +31,7 @@ class TabbedView(BrowserView):
     """A View containing tabs with fancy ui"""
 
     __call__ = ViewPageTemplateFile("tabbed.pt")
+    macros = __call__.macros
 
     def user_is_logged_in(self):
         user = AccessControl.getSecurityManager().getUser()


### PR DESCRIPTION
In some cases the TabbedView title should be customizable, for example when you need a dynamic value.

With this changes it's easy to overwrite the title value in a simple custom template:

```
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      xmlns:metal="http://xml.zope.org/namespaces/metal"
      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
      lang="en"
      metal:use-macro="context/@@tabbed_view/macros/master"
      i18n:domain="ftw.tabbedview">

  <metal:title metal:fill-slot="content-title">
    <h1 class="documentFirstHeading" tal:content="view/dynamic_title">
    </h1>
  </metal:title>

</html>
```

Used by https://github.com/4teamwork/opengever.core/issues/284

\cc @maethu, @jone 
