### PR TITLE
Use base URL for AJAX request to `set_default_tab`

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.3.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- JS: Use base URL to build absolute URL for set_default_tab.
+  [lgraf]
 
 
 3.3.11 (2014-05-28)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -513,9 +513,10 @@ load_tabbedview = function(callback) {
         var viewname = $.grep(
             $('body').attr('class').split(' '),
             function(name, i) { return name.indexOf('template-') === 0; })[0].split('-')[1];
+        var url = baseurl+'@@tabbed_view/set_default_tab';
 
         $.ajax({
-            'url': '@@tabbed_view/set_default_tab',
+            'url': url,
             cache: false,
             type: 'POST',
             dataType: 'json',


### PR DESCRIPTION
Somehow the AJAX request to `@@tabbed_view/set_default_tab` ends up going to
- `container/@@tabbed_view/set_default_tab` instead of 
- `container/context/@@tabbed_view/set_default_tab` 

for non-folderish contexts.

Unlike regular HTML links, the jQuery `$.ajax()` call [ignores the base URL](http://stackoverflow.com/a/9079801/1599111) when creating requests from relative URLs. So one would expect that it behaves the same like regular links in HTML do: A relative URL `foo` will turn into
- `http://container/context/foo` for a location of `http://container/context/` (trailing slash), and into
- `http://container/foo` for a location of `http://container/context` (no trailing slash).

However, this does not seem to be the case. The request at [`tabbedview.js:521`](https://github.com/4teamwork/ftw.tabbedview/blob/988b9bd566147cfd61ed2ba90121fd02dbe840d1/ftw/tabbedview/browser/resources/tabbedview.js#L521) always ends up going to `container/@@tabbed_view/set_default_tab`, with trailing slash or without.

Therefore I change the AJAX call in this PR to always build absolute URLs using the base URL (which Plone sets correctly).

@maethu @jone please review.
