### PR TITLE
pin down zope.testrunner because of isolation problems.

### DIFF
--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -2,5 +2,6 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
     sources.cfg
+    versions.cfg
 
 package-name = ftw.tabbedview

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -2,5 +2,6 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
     sources.cfg
+    versions.cfg
 
 package-name = ftw.tabbedview

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -2,5 +2,6 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     sources.cfg
+    versions.cfg
 
 package-name = ftw.tabbedview

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,4 @@
+[versions]
+# zope.testrunner 4.4.5 has changed the testing layer ordering
+# which causes test isolation problems with the ZCML layer.
+zope.testrunner = 4.4.4


### PR DESCRIPTION
zope.testrunner 4.4.5 has changed the testing layer ordering
which causes test isolation problems with the ZCML layer.