### PR TITLE
Fixed initial tab marker (default-tab).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.3.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed initial tab marker (default-tab).
+  [phgross]
 
 
 3.3.13 (2014-08-28)

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -73,6 +73,7 @@ class TabbedView(BrowserView):
         actions = []
 
         for action in self.get_tabs():
+            action = action.copy()
             if action['id'].lower() == default_tab:
                 action['class'] = '%s initial' % action['class']
 

--- a/ftw/tabbedview/tests/test_load_package.py
+++ b/ftw/tabbedview/tests/test_load_package.py
@@ -1,17 +1,21 @@
-from Products.CMFCore.utils import getToolByName
+from ftw.dictstorage.interfaces import IDictStorage
 from ftw.tabbedview.browser.tabbed import TabbedView
+from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
 from ftw.tabbedview.testing import TABBEDVIEW_INTEGRATION_TESTING
+from Products.CMFCore.utils import getToolByName
 from pyquery import PyQuery as pq
 from unittest2 import TestCase
+from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 
 
 class FoobarView(TabbedView):
+
+    tabs = [{'id': 'footab', 'class': None, 'title': 'MyTitle'},
+            {'id': 'bartab', 'class': None, 'title': 'Bar'}]
+
     def get_tabs(self):
-        return [{'id': 'footab',
-                 'class': None,
-                 'title': 'MyTitle'}
-        ]
+        return self.tabs
 
 
 class TestWWWInstallation(TestCase):
@@ -33,3 +37,27 @@ class TestWWWInstallation(TestCase):
         tabs_html = doc('#tabbedview-header .tabbedview-tabs')
         self.assertGreater(len(tabs_html('#tab-footab')), 0)
         self.assertIn('MyTitle', tabs_html.html())
+
+    def test_initial_tab_is_reseted_on_every_request(self):
+        portal = self.layer['portal']
+        foobar_view = queryMultiAdapter((portal, portal.REQUEST),
+                                        name='tabbed_view')
+        key_generator = getMultiAdapter((portal, foobar_view, portal.REQUEST),
+                                        IDefaultTabStorageKeyGenerator)
+        key = key_generator.get_key()
+
+        # first call
+        IDictStorage(foobar_view)[key] = 'footab'
+        html = foobar_view()
+        doc = pq(html)
+        initial_tab = doc('#tabbedview-header .tabbedview-tabs a.initial')
+        self.assertEqual(1, len(initial_tab))
+        self.assertEqual('MyTitle', initial_tab.text())
+
+        # second call
+        IDictStorage(foobar_view)[key] = 'bartab'
+        html = foobar_view()
+        doc = pq(html)
+        initial_tab = doc('#tabbedview-header .tabbedview-tabs a.initial')
+        self.assertEqual(1, len(initial_tab))
+        self.assertEqual('Bar', initial_tab.text())


### PR DESCRIPTION
If a tabbedview stores tis tab on the view itself (see https://github.com/4teamwork/opengever.core/blob/master/opengever/tabbedview/browser/personal_overview.py#L37 for an example), the `initial` class is written to the action itself. Therefore the default tab functionality does not work proper in this case, because the initial class is not reseted after a default-tab change.

@jone please have a look ... 