### PR TITLE
Remove whitespace around title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove whitespace around content title.
+  [deiferni]
 
 
 3.4.0 (2015-05-26)

--- a/ftw/tabbedview/browser/tabbed.pt
+++ b/ftw/tabbedview/browser/tabbed.pt
@@ -45,9 +45,7 @@
 
 
           <metal:title define-slot="content-title">
-            <h1 class="documentFirstHeading">
-              <tal:title replace="context/Title" />
-            </h1>
+            <h1 class="documentFirstHeading" tal:content="context/Title" />
           </metal:title>
           <div tal:replace="structure provider:plone.belowcontenttitle" />
 


### PR DESCRIPTION
This is consistent with other plone viewlets and relevant when placing content
before the title via css::before (e.g.: when adding a content-type icon).