### PR TITLE
Throws javascript error in dossieroverview in IE10.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix javascript error in IE10 when no default index is defined.
+  [Kevin Bieri]
 
 
 3.4.1 (2015-08-03)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -330,6 +330,9 @@ load_tabbedview = function(callback) {
             if (jQuery.tabbedview.param('initialize') !== 1) {
                 jQuery.tabbedview.view_container.addClass('loading_tab');
                 var tabbedview = jQuery.tabbedview;
+                if(!index) {
+                  index = 0;
+                }
                 var current_tab_id = $('.tabbedview-tabs li a').get(index).id.split('tab-')[1];
 
                 jQuery.tabbedview.show_spinner();


### PR DESCRIPTION
Fixes #45 

When no index is defined set to 0 to display the first tab.