### PR TITLE
Handle redirects during tabbed-view requests.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    test-plone-4.3.x.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 3.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle when the client gets a response from different source than a tabbed-view.
+  By default show a message that the tab could not be loaded successfully. This can
+  be customized by registering a different event handler.
+  [deiferni]
 
 
 3.4.2 (2015-09-01)

--- a/ftw/tabbedview/browser/configure.zcml
+++ b/ftw/tabbedview/browser/configure.zcml
@@ -21,7 +21,7 @@
         name="tabbed_view"
         class=".tabbed.TabbedView"
         permission="zope2.View"
-        allowed_attributes="listing select_all reorder setgridstate set_default_tab"
+        allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
         />
 
     <browser:page

--- a/ftw/tabbedview/browser/resources/tabbedview.css
+++ b/ftw/tabbedview/browser/resources/tabbedview.css
@@ -71,3 +71,7 @@
   width: 16px;
   height: 16px;
 }
+
+#tabbedview-msg-unknownresponse {
+  display: none;
+}

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -36,6 +36,10 @@ if( baseurl.substr(baseurl.length-1, 1) != '/'){
   baseurl += '/';
 }
 
+$(document).bind('tabbedview.unknownresponse', function(event, overview, jqXHR) {
+  overview.html($('#tabbedview-msg-unknownresponse').html());
+});
+
 load_tabbedview = function(callback) {
   /*statusmessages = $('#region-content').statusmessages()*/
 
@@ -63,8 +67,18 @@ load_tabbedview = function(callback) {
       var current_tab = $('.tabbedview-tabs li a.selected');
       var overview = $('#'+tabbedview.prop('view_name')+'_overview');
       var url = baseurl + 'tabbed_view/listing?ajax_load=1&'+params;
-      overview.load(url, function(){
-
+      $.get(url, function(responseText, textStatus, jqXHR){
+        if (jqXHR.getResponseHeader('X-Tabbedview-Response') === null) {
+          // the response we got does not originate from a tabbed-view
+          overview.trigger('tabbedview.unknownresponse', [overview, jqXHR])
+          tabbedview.hide_spinner();
+          tabbedview.update_tab_menu();
+          if (typeof callback == "function"){
+            callback(tabbedview);
+          }
+          return;
+        }
+        overview.html(responseText);
         // call callback
         if (typeof callback == "function"){
           callback(tabbedview);

--- a/ftw/tabbedview/browser/tabbed.pt
+++ b/ftw/tabbedview/browser/tabbed.pt
@@ -36,7 +36,6 @@
     <div metal:fill-slot="main" class="tabbedview_view"
          tal:define="came_from python:request.get('HTTP_REFERER', context.absolute_url()).split('?')[0];">
       <metal:main-macro define-macro="main">
-
         <tal:variables define="tabs view/get_tab_items">
 
         <div id="tabbedview-header">
@@ -52,6 +51,10 @@
           <metal:befortabs define-slot="before-tabs">
 
           </metal:befortabs>
+
+          <div id="tabbedview-msg-unknownresponse">
+            <p tal:content="structure view/msg_unknownresponse"></p>
+          </div>
 
           <div class="tabbedview-tabs">
             <ul class="formTabs">

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -151,6 +151,7 @@ class TabbedView(BrowserView):
                     (self.context, self.request),
                     name='tabbedview_view-fallback')
 
+            self.request.response.setHeader('X-Tabbedview-Response', True)
             return listing_view()
 
     def reorder(self):
@@ -284,3 +285,15 @@ class TabbedView(BrowserView):
         storage.set(key, tab.lower())
 
         return json.dumps(success)
+
+    def msg_unknownresponse(self):
+        """Return the message that is rendered when a javascript request gets
+        a response from a different source than a tabbed view.
+
+        This happens when a redirect occurs, for example a redirect to a login
+        form due to a session timeout.
+        """
+        return _('There was an error loading the tab. Try '
+                 '${anchor_open}reloading${anchor_close} the page.',
+                 mapping={'anchor_open': '<a href="#" onclick="window.location.reload();">',
+                          'anchor_close': '</a>'})

--- a/ftw/tabbedview/configure.zcml
+++ b/ftw/tabbedview/configure.zcml
@@ -5,8 +5,7 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:meta="http://namespaces.zope.org/meta"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:cmf="http://namespaces.zope.org/cmf"
-    i18n_domain="ftw.tabbedview">
+    xmlns:cmf="http://namespaces.zope.org/cmf">
 
 
     <!-- Include configuration for dependencies listed in setup.py -->

--- a/ftw/tabbedview/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2013-06-12 07:25+0000\n"
+"POT-Creation-Date: 2016-02-24 11:34+0000\n"
 "PO-Revision-Date: 2011-12-16 10:48+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -10,7 +10,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 #: ./ftw/tabbedview/browser/selection.pt:14
 msgid "All visible entries chosen ${show_all_link}"
@@ -27,7 +26,7 @@ msgstr "Ersteller"
 msgid "Lines per page:"
 msgstr "Zeilen pro Seite:"
 
-#: ./ftw/tabbedview/browser/tabbed.py:95
+#: ./ftw/tabbedview/browser/tabbed.py:97
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr "Setzt das aktuelle Tab als Standard-Tab dieser Ansicht. Diese Einstellung ist persönlich."
 
@@ -40,9 +39,13 @@ msgstr "Tabellenkonfiguration zurücksetzen"
 msgid "Resets the table configuration for this tab."
 msgstr "Konfiguration der Tabelle dieses Tabs auf den Standard zurücksetzen."
 
-#: ./ftw/tabbedview/browser/tabbed.py:93
+#: ./ftw/tabbedview/browser/tabbed.py:95
 msgid "Set tab as default"
 msgstr "Als Standard-Tab verwenden"
+
+#: ./ftw/tabbedview/browser/tabbed.py:296
+msgid "There was an error loading the tab. Try ${anchor_open}reloading${anchor_close} the page."
+msgstr "Das Tab konnte nicht geladen werden. Probieren Sie die Seite ${anchor_open}neu zu laden${anchor_close}."
 
 msgid "Title"
 msgstr "Titel"
@@ -60,11 +63,11 @@ msgid "end"
 msgstr "Ende"
 
 #. Default: "Could not set default tab."
-#: ./ftw/tabbedview/browser/tabbed.py:257
+#: ./ftw/tabbedview/browser/tabbed.py:260
 msgid "error_set_default_tab"
 msgstr "Fehler beim setzen des Standard-Tab."
 
-#: ./ftw/tabbedview/browser/searchbox.pt:3
+#: ./ftw/tabbedview/browser/searchbox.pt:7
 msgid "filter"
 msgstr "Filtern"
 
@@ -72,12 +75,12 @@ msgid "hours"
 msgstr "geleist. Std."
 
 #. Default: "The tab ${title} is now your default tab. This is a personal setting."
-#: ./ftw/tabbedview/browser/tabbed.py:265
+#: ./ftw/tabbedview/browser/tabbed.py:268
 msgid "info_set_default_tab"
 msgstr "Das Tab ${title} wird nun als Standard-Tab verwendet. Dies ist eine persönliche Einstellung."
 
 #. Default: "Filter"
-#: ./ftw/tabbedview/browser/searchbox.pt:2
+#: ./ftw/tabbedview/browser/searchbox.pt:3
 msgid "label_filter"
 msgstr "Filter"
 
@@ -101,3 +104,4 @@ msgstr "Beginn"
 
 msgid "state"
 msgstr "Status"
+

--- a/ftw/tabbedview/locales/en/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/en/LC_MESSAGES/ftw.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-06-12 07:25+0000\n"
+"POT-Creation-Date: 2016-02-24 11:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,7 +10,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 #: ./ftw/tabbedview/browser/selection.pt:14
 msgid "All visible entries chosen ${show_all_link}"
@@ -27,7 +26,7 @@ msgstr "Creator"
 msgid "Lines per page:"
 msgstr ""
 
-#: ./ftw/tabbedview/browser/tabbed.py:95
+#: ./ftw/tabbedview/browser/tabbed.py:97
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 
@@ -40,9 +39,13 @@ msgstr "Reset table configuration"
 msgid "Resets the table configuration for this tab."
 msgstr "Resets the table configuration for this tab."
 
-#: ./ftw/tabbedview/browser/tabbed.py:93
+#: ./ftw/tabbedview/browser/tabbed.py:95
 msgid "Set tab as default"
 msgstr "Set tab as default"
+
+#: ./ftw/tabbedview/browser/tabbed.py:296
+msgid "There was an error loading the tab. Try ${anchor_open}reloading${anchor_close} the page."
+msgstr "There was an error loading the tab. Try ${anchor_open}reloading${anchor_close} the page."
 
 msgid "Title"
 msgstr "Title"
@@ -60,11 +63,11 @@ msgid "end"
 msgstr "End"
 
 #. Default: "Could not set default tab."
-#: ./ftw/tabbedview/browser/tabbed.py:257
+#: ./ftw/tabbedview/browser/tabbed.py:260
 msgid "error_set_default_tab"
 msgstr "Could not set default tab."
 
-#: ./ftw/tabbedview/browser/searchbox.pt:3
+#: ./ftw/tabbedview/browser/searchbox.pt:7
 msgid "filter"
 msgstr "Filter"
 
@@ -72,11 +75,11 @@ msgid "hours"
 msgstr "Hours"
 
 #. Default: "The tab ${title} is now your default tab. This is a personal setting."
-#: ./ftw/tabbedview/browser/tabbed.py:265
+#: ./ftw/tabbedview/browser/tabbed.py:268
 msgid "info_set_default_tab"
 msgstr "The tab ${title} is now your default tab. This is a personal setting."
 
-#: ./ftw/tabbedview/browser/searchbox.pt:2
+#: ./ftw/tabbedview/browser/searchbox.pt:3
 msgid "label_filter"
 msgstr "Filter"
 
@@ -100,3 +103,4 @@ msgstr "Start"
 
 msgid "state"
 msgstr "Status"
+

--- a/ftw/tabbedview/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-06-12 07:25+0000\n"
+"POT-Creation-Date: 2016-02-24 11:34+0000\n"
 "PO-Revision-Date: 2012-09-10 10:03+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,7 +10,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 #: ./ftw/tabbedview/browser/selection.pt:14
 msgid "All visible entries chosen ${show_all_link}"
@@ -27,7 +26,7 @@ msgstr "Créateur"
 msgid "Lines per page:"
 msgstr "Lignes par page :"
 
-#: ./ftw/tabbedview/browser/tabbed.py:95
+#: ./ftw/tabbedview/browser/tabbed.py:97
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr "Faire de l'onglet actuel l'onglet par défaut quand on ouvre cette vue. Ceci est un réglage personnel qui n'a aucun impact pour les autres utilisateurs."
 
@@ -40,9 +39,13 @@ msgstr "Remettre la configuration par défaut des colonnes"
 msgid "Resets the table configuration for this tab."
 msgstr "Réinitialiser la table de configuration pour cet onglet."
 
-#: ./ftw/tabbedview/browser/tabbed.py:93
+#: ./ftw/tabbedview/browser/tabbed.py:95
 msgid "Set tab as default"
 msgstr "Définir cet onglet par défaut"
+
+#: ./ftw/tabbedview/browser/tabbed.py:296
+msgid "There was an error loading the tab. Try ${anchor_open}reloading${anchor_close} the page."
+msgstr ""
 
 msgid "Title"
 msgstr "Titre"
@@ -60,11 +63,11 @@ msgid "end"
 msgstr "Fin"
 
 #. Default: "Could not set default tab."
-#: ./ftw/tabbedview/browser/tabbed.py:257
+#: ./ftw/tabbedview/browser/tabbed.py:260
 msgid "error_set_default_tab"
 msgstr "Impossible de définir cet onglet défaut"
 
-#: ./ftw/tabbedview/browser/searchbox.pt:3
+#: ./ftw/tabbedview/browser/searchbox.pt:7
 msgid "filter"
 msgstr "Filtre"
 
@@ -72,11 +75,11 @@ msgid "hours"
 msgstr "Heures effectués"
 
 #. Default: "The tab ${title} is now your default tab. This is a personal setting."
-#: ./ftw/tabbedview/browser/tabbed.py:265
+#: ./ftw/tabbedview/browser/tabbed.py:268
 msgid "info_set_default_tab"
 msgstr "Cet onglet est maintenant votre onglet par défaut. Ce choix est personnel."
 
-#: ./ftw/tabbedview/browser/searchbox.pt:2
+#: ./ftw/tabbedview/browser/searchbox.pt:3
 msgid "label_filter"
 msgstr "Filtre"
 
@@ -100,3 +103,4 @@ msgstr "Début"
 
 msgid "state"
 msgstr "Etat"
+

--- a/ftw/tabbedview/locales/ftw.tabbedview.pot
+++ b/ftw/tabbedview/locales/ftw.tabbedview.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-06-12 07:25+0000\n"
+"POT-Creation-Date: 2016-02-24 11:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,10 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.tabbedview\n"
 
 #: ./ftw/tabbedview/browser/selection.pt:14
 msgid "All visible entries chosen ${show_all_link}"
@@ -32,7 +29,7 @@ msgstr ""
 msgid "Lines per page:"
 msgstr ""
 
-#: ./ftw/tabbedview/browser/tabbed.py:95
+#: ./ftw/tabbedview/browser/tabbed.py:97
 msgid "Make the current tab the default tab when opening this view. This is a personal setting and does not impact other users."
 msgstr ""
 
@@ -45,8 +42,12 @@ msgstr ""
 msgid "Resets the table configuration for this tab."
 msgstr ""
 
-#: ./ftw/tabbedview/browser/tabbed.py:93
+#: ./ftw/tabbedview/browser/tabbed.py:95
 msgid "Set tab as default"
+msgstr ""
+
+#: ./ftw/tabbedview/browser/tabbed.py:296
+msgid "There was an error loading the tab. Try ${anchor_open}reloading${anchor_close} the page."
 msgstr ""
 
 msgid "Title"
@@ -65,11 +66,11 @@ msgid "end"
 msgstr ""
 
 #. Default: "Could not set default tab."
-#: ./ftw/tabbedview/browser/tabbed.py:257
+#: ./ftw/tabbedview/browser/tabbed.py:260
 msgid "error_set_default_tab"
 msgstr ""
 
-#: ./ftw/tabbedview/browser/searchbox.pt:3
+#: ./ftw/tabbedview/browser/searchbox.pt:7
 msgid "filter"
 msgstr ""
 
@@ -77,11 +78,11 @@ msgid "hours"
 msgstr ""
 
 #. Default: "The tab ${title} is now your default tab. This is a personal setting."
-#: ./ftw/tabbedview/browser/tabbed.py:265
+#: ./ftw/tabbedview/browser/tabbed.py:268
 msgid "info_set_default_tab"
 msgstr ""
 
-#: ./ftw/tabbedview/browser/searchbox.pt:2
+#: ./ftw/tabbedview/browser/searchbox.pt:3
 msgid "label_filter"
 msgstr ""
 

--- a/ftw/tabbedview/upgrades/configure.zcml
+++ b/ftw/tabbedview/upgrades/configure.zcml
@@ -1,8 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
-    i18n_domain="ftw.tabbedview">
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade">
 
     <include package="ftw.upgrade" file="meta.zcml" />
 


### PR DESCRIPTION
When a users session is removed (timeout, logout in another tab, ...) or when the response is redirected for another reason tabbed-view layout can be broken when attempting to render the response:
![before](https://cloud.githubusercontent.com/assets/736583/13286749/93f5fbfa-db03-11e5-9054-f5660f157114.gif)

This PR addresses that issue by adding a custom header on the server side to each tabbed-view response. The client then checks if the header is present, if this is not the case the response is discarded and error message is displayed:
![after](https://cloud.githubusercontent.com/assets/736583/13286574/9bc6dd50-db02-11e5-8aef-9c611c01463d.gif)

I did not want to trigger a reload all the time to avoid reload-loops when the the page containing the tabbed-view can be loaded, but only the tab fails/redirects for some reason. If a custom action is required this can be implemented by adding an event handler, e.g.:

```javascript
$(document).delegate('body', 'tabbedview.unknownresponse', function(event, overview, jqXHR) {
  if (jqXHR.getResponseHeader('X-GEVER-Service') === 'Portal') {
    // the response we got originates from a portal, we reload to show the login window
    location.reload();
    return false;
  }
});
```

@jone or @maethu please have a good look (if you're interested a demo of the implementation is currently running on https://lab.onegovgever.ch/)

Note that this will break custom `TabbedView` implementations, that do not set the required header in `listing`, should they exist.

This PR also adds a development configuration to be able to use the `i18n-build` script. It also removes i18n_domain attribute from config files that are not translated.