### PR TITLE
Respect permissions defined on tabs during tab-lookup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 3.4.4 (unreleased)
 ------------------
 
+- Respect permissions defined on tabs during tab-lookup.
+  Replaces adapter lookup with traversal to make sure that permissions
+  defined on a tab are respected.
+  [deiferni]
+
 - Handle when the client gets a response from different source than a tabbed-view.
   By default show a message that the tab could not be loaded successfully. This can
   be customized by registering a different event handler.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.4.4 (unreleased)
 ------------------
 
+- Drop support for Plone 4.1.x.
+  [deiferni]
+
 - Respect permissions defined on tabs during tab-lookup.
   Replaces adapter lookup with traversal to make sure that permissions
   defined on a tab are respected.

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -54,8 +54,10 @@ class TabbedView(BrowserView):
             css_classes = None
             #get the css classes that should be set on the A elements.
             view = self._resolve_tab(action['id'])
+            if not view:
+                continue
 
-            if view and hasattr(view, 'get_css_classes'):
+            if hasattr(view, 'get_css_classes'):
                 css_classes = ' '.join(view.get_css_classes())
 
             yield {

--- a/ftw/tabbedview/testing.py
+++ b/ftw/tabbedview/testing.py
@@ -34,21 +34,25 @@ class TabbedViewLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE, )
 
     def setUpZope(self, app, configurationContext):
-        import z3c.autoinclude
-        xmlconfig.file('meta.zcml', z3c.autoinclude,
-                       context=configurationContext)
         xmlconfig.string(
             '<configure xmlns="http://namespaces.zope.org/zope">'
+            '  <include package="z3c.autoinclude" file="meta.zcml" />'
             '  <includePlugins package="plone" />'
+            '  <includePluginsOverrides package="plone" />'
             '</configure>',
             context=configurationContext)
 
         import ftw.tabbedview.tests
         xmlconfig.file('tests.zcml', ftw.tabbedview.tests,
                        context=configurationContext)
+        xmlconfig.file('tabs.zcml', ftw.tabbedview.tests,
+                       context=configurationContext)
+        xmlconfig.file('profiles/profiles.zcml', ftw.tabbedview.tests,
+                       context=configurationContext)
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.tabbedview:default')
+        applyProfile(portal, 'ftw.tabbedview.tests:tabs')
 
 
 TABBED_VIEW_LAYER = TabbedViewLayer()

--- a/ftw/tabbedview/tests/locales/en/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/tests/locales/en/LC_MESSAGES/ftw.tabbedview.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+
+msgid "footab"
+msgstr "MyTitle"
+
+msgid "restrictedtab"
+msgstr "Restricted Tab"

--- a/ftw/tabbedview/tests/locales/ftw.tabbedview.pot
+++ b/ftw/tabbedview/tests/locales/ftw.tabbedview.pot
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+
+msgid "footab"
+msgstr ""
+
+msgid "notranslation"
+msgstr ""
+
+msgid "restrictedtab"
+msgstr ""

--- a/ftw/tabbedview/tests/profiles/profiles.zcml
+++ b/ftw/tabbedview/tests/profiles/profiles.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="ftw.testing.tests">
+
+    <include package="Products.GenericSetup" file="meta.zcml" />
+
+    <genericsetup:registerProfile
+        name="tabs"
+        title="ftw.tabbedview.tests:tabs"
+        directory="tabs"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+</configure>

--- a/ftw/tabbedview/tests/profiles/tabs/types/Plone_Site.xml
+++ b/ftw/tabbedview/tests/profiles/tabs/types/Plone_Site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<object name="Plone Site"
+        i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Tab Actions -->
+  <action title="MyTitle"
+          action_id="footab"
+          category="tabbedview-tabs"
+          condition_expr=""
+          url_expr="string:#"
+          visible="True">
+  </action>
+  <action title="Bar"
+          action_id="notranslation"
+          category="tabbedview-tabs"
+          condition_expr=""
+          url_expr="string:#"
+          visible="True">
+  </action>
+  <action title="Restricted Tab"
+          action_id="restrictedtab"
+          category="tabbedview-tabs"
+          condition_expr=""
+          url_expr="string:#"
+          visible="True">
+  </action>
+
+</object>

--- a/ftw/tabbedview/tests/tabs.py
+++ b/ftw/tabbedview/tests/tabs.py
@@ -1,0 +1,15 @@
+from ftw.tabbedview.browser.listing import ListingView
+
+
+class PublicTab(ListingView):
+    pass
+
+
+class SomeOtherTab(ListingView):
+
+    def get_css_classes(self):
+        return 'something'
+
+
+class RestrictedTab(ListingView):
+    pass

--- a/ftw/tabbedview/tests/tabs.zcml
+++ b/ftw/tabbedview/tests/tabs.zcml
@@ -1,0 +1,32 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:meta="http://namespaces.zope.org/meta"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+    <include package="Products.CMFCore"/>
+
+    <i18n:registerTranslations directory="locales" />
+
+    <browser:page
+        for="*"
+        name="tabbedview_view-footab"
+        class=".tabs.PublicTab"
+        permission="zope2.View"
+        />
+
+    <browser:page
+        for="*"
+        name="tabbedview_view-notranslation"
+        class=".tabs.PublicTab"
+        permission="zope2.View"
+        />
+
+    <browser:page
+        for="*"
+        name="tabbedview_view-restrictedtab"
+        class=".tabs.RestrictedTab"
+        permission="cmf.ModifyPortalContent"
+        />
+
+</configure>

--- a/ftw/tabbedview/tests/test_fallback.py
+++ b/ftw/tabbedview/tests/test_fallback.py
@@ -1,33 +1,16 @@
-from ftw.tabbedview.testing import ZCML_LAYER
+from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
 from ftw.testing import MockTestCase
-from zope.component import queryMultiAdapter, getMultiAdapter
-from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
 class TestFallBackView(MockTestCase):
 
-    layer = ZCML_LAYER
+    layer = TABBEDVIEW_FUNCTIONAL_TESTING
 
-    def test_component_registered(self):
-        context = self.stub()
-        request = self.providing_stub(IDefaultBrowserLayer)
-
-        self.replay()
-
-        view = queryMultiAdapter((context, request),
-                                 name='tabbedview_view-fallback')
-        self.assertNotEqual(view, None)
-
-    def test_render_view(self):
-        context = self.create_dummy()
-        request = self.stub_request()
-
-        self.expect(request.get('view_name', '')).result('foo')
-
-        self.replay()
-
-        view = getMultiAdapter((context, request),
-                               name='tabbedview_view-fallback')
-        html = view()
-        self.assertIn('No view registered for', html)
-        self.assertIn('foo', html)
+    @browsing
+    def test_fallback_view_is_registered(self, browser):
+        browser.login().open(view='tabbedview_view-fallback',
+                             data={'view_name': 'foo'})
+        self.assertEqual(
+            'No view registered for: tabbedview_view-foo',
+            browser.css('body').first.text)

--- a/ftw/tabbedview/tests/test_load_package.py
+++ b/ftw/tabbedview/tests/test_load_package.py
@@ -1,5 +1,4 @@
 from ftw.dictstorage.interfaces import IDictStorage
-from ftw.tabbedview.browser.tabbed import TabbedView
 from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
 from ftw.tabbedview.testing import TABBEDVIEW_INTEGRATION_TESTING
 from Products.CMFCore.utils import getToolByName
@@ -7,15 +6,6 @@ from pyquery import PyQuery as pq
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
-
-
-class FoobarView(TabbedView):
-
-    tabs = [{'id': 'footab', 'class': None, 'title': 'MyTitle'},
-            {'id': 'bartab', 'class': None, 'title': 'Bar'}]
-
-    def get_tabs(self):
-        return self.tabs
 
 
 class TestWWWInstallation(TestCase):

--- a/ftw/tabbedview/tests/test_load_package.py
+++ b/ftw/tabbedview/tests/test_load_package.py
@@ -16,17 +16,7 @@ class TestWWWInstallation(TestCase):
         portal = self.layer['portal']
         csstool = getToolByName(portal, 'portal_css')
         self.assertTrue(csstool.getResource(
-                '++resource++ftw.tabbedview-resources/tabbedview.css'))
-
-    def test_tab_titles(self):
-        portal = self.layer['portal']
-        foobar_view = queryMultiAdapter((portal, portal.REQUEST),
-                                        name='tabbed_view')
-        html = foobar_view()
-        doc = pq(html)
-        tabs_html = doc('#tabbedview-header .tabbedview-tabs')
-        self.assertGreater(len(tabs_html('#tab-footab')), 0)
-        self.assertIn('MyTitle', tabs_html.html())
+            '++resource++ftw.tabbedview-resources/tabbedview.css'))
 
     def test_initial_tab_is_reseted_on_every_request(self):
         portal = self.layer['portal']
@@ -45,9 +35,9 @@ class TestWWWInstallation(TestCase):
         self.assertEqual('MyTitle', initial_tab.text())
 
         # second call
-        IDictStorage(foobar_view)[key] = 'bartab'
+        IDictStorage(foobar_view)[key] = 'notranslation'
         html = foobar_view()
         doc = pq(html)
         initial_tab = doc('#tabbedview-header .tabbedview-tabs a.initial')
         self.assertEqual(1, len(initial_tab))
-        self.assertEqual('Bar', initial_tab.text())
+        self.assertEqual('notranslation', initial_tab.text())

--- a/ftw/tabbedview/tests/test_tabbed_view.py
+++ b/ftw/tabbedview/tests/test_tabbed_view.py
@@ -1,0 +1,40 @@
+from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+import transaction
+
+
+class TestTabPermissions(TestCase):
+
+    layer = TABBEDVIEW_FUNCTIONAL_TESTING
+
+    @browsing
+    def test_restricted_tabs_invisible_with_unprivileded_user(self, browser):
+        browser.login().visit(view='tabbed_view')
+        self.assertEqual(['MyTitle', 'notranslation'],
+                         browser.css('.tabbedview-tabs .formTab').text)
+
+    @browsing
+    def test_restricted_tabs_visible_with_privileded_user(self, browser):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Member', 'Editor'])
+        transaction.commit()
+
+        browser.login().visit(view='tabbed_view')
+        self.assertEqual(['MyTitle', 'notranslation', 'Restricted Tab'],
+                         browser.css('.tabbedview-tabs .formTab').text)
+
+    def test_get_tabs(self):
+        view = self.layer['portal'].restrictedTraverse('tabbed_view')
+
+        self.assertEqual([
+            {'url': '#',
+             'class': 'searchform-visible',
+             'id': 'footab',
+             'icon': None},
+            {'url': '#',
+             'class': 'searchform-visible',
+             'id': 'notranslation',
+             'icon': None}],
+            list(view.get_tabs()))

--- a/ftw/tabbedview/tests/tests.zcml
+++ b/ftw/tabbedview/tests/tests.zcml
@@ -21,11 +21,4 @@
 
     <include package="ftw.tabbedview" />
 
-    <browser:page
-        for="*"
-        name="tabbed_view"
-        class=".test_load_package.FoobarView"
-        permission="zope2.View"
-        />
-
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(name='ftw.tabbedview',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ maintainer = 'Jonas Baumann'
 tests_require = [
     'plone.app.testing',
     'pyquery',
+    'ftw.testbrowser',
     'ftw.testing',
     ]
 

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,7 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-    sources.cfg
-    versions.cfg
-
-package-name = ftw.tabbedview


### PR DESCRIPTION
Currently permissions defined for the view responsible for a tab of a tabbed-view (i.e. `tabbedview_view-myview`) are ignored/bypassed during tab-lookup which is implemented with an adapter lookup.

This PR replaces adapter-query tab-lookup with tab-lookup using traversals `restrictedTraverse`. This method always enforces security and thus won't return tabs where the current user does not have the required permissions.

With this PR tabs that define permissions different from `zope2.View` will no longer be displayed if the user does not have the required permission to access the view responsible for the tab. This not only affects tab-content but also the list of tabs displayed in `.tabbedview-tabs`.

Furthermore i attempted to improve the test setup by removing some mocks in favour of `ftw.testbrowser` tests. The tabs we test against are now registered as `action` and discovered as in a productive environment. 

As discussed with @jone Plone 4.1 support can be dropped.

Fixes #50.