### PR TITLE
Move uploadbox above tabbedview menu

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.5.1 (unreleased)
 ------------------
 
+- Move uploadbox above tabbedview menu
+  [Kevin Bieri]
+
 - Change Regex in parse_param. Only match decimal characters, since parseFloat may return wrong results when confronted with an int.
   [tschanzt]
 

--- a/ftw/tabbedview/browser/tabbed.pt
+++ b/ftw/tabbedview/browser/tabbed.pt
@@ -76,6 +76,18 @@
 
         <div class="visualClear" ></div>
         <div id="tabbedview-body" class="panes">
+            <div id="uploadbox" class="uploaderContainer" tal:condition="view/show_uploadbox">
+                <a tal:attributes="href string:${context/absolute_url}/quick_upload"
+                   class="uploadUrl" style="display:none ">
+                    <!-- link for html5 upload -->
+                </a>
+                <input type="hidden"
+                       name="uploadData"
+                       class="uploadData"
+                       value=""
+                       />
+            </div>
+
             <dl class="actionMenu tabbedview-tab-menu"
                 tal:condition="view/user_is_logged_in">
                 <dt class="actionMenuHeader tabbedviewMenuHeader">
@@ -103,18 +115,6 @@
                     </dd>
                 </tal:tab>
             </dl>
-
-          <div id="uploadbox" class="uploaderContainer" tal:condition="view/show_uploadbox">
-              <a tal:attributes="href string:${context/absolute_url}/quick_upload"
-                 class="uploadUrl" style="display:none ">
-                  <!-- link for html5 upload -->
-              </a>
-              <input type="hidden"
-                     name="uploadData"
-                     class="uploadData"
-                     value=""
-                     />
-          </div>
 
             <tal:panes repeat="tab tabs">
                 <div tal:attributes="id python:'%s_overview' % tab['id']" class="pane"><!-- iefix --></div>


### PR DESCRIPTION
In opengever.core we have issues displaying the uploadbox next to
the bumblebee view chooser.
So the best solution is to move the uploadbox above the tabbedview menu.

@4teamwork/dev-plone Attention: This may cause side effects in other projects but @phgross doesn't care 😉 .

See https://github.com/4teamwork/opengever.core/issues/1851