### PR TITLE
update regex to only match decimals shorter than 17 digits.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change Regex in parse_param. Only match decimal characters, since parseFloat may return wrong results when confronted with an int.
+  [tschanzt]
 
 
 3.5.0 (2016-03-07)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -8,7 +8,7 @@ jQuery.find_param = function(s) {
       var splitted = this.split('=');
       var key = splitted[0];
       var val = splitted[1];
-      if (/^[0-9.]+$/.test(val)) {
+      if (/^[0-9.]{1,16}$/.test(val)) {
         val = parseFloat(val);
       }
       if (val == 'true') {


### PR DESCRIPTION
@jone this regex so we only use parseFloat for numbers which are shorter or equal than 16 digits because it isn't working correctly afterwards.

![screen shot 2016-08-11 at 17 23 22](https://cloud.githubusercontent.com/assets/358342/17594150/8f4022ce-5fe8-11e6-906d-421708bb8680.png)
![screen shot 2016-08-11 at 16 56 13](https://cloud.githubusercontent.com/assets/358342/17594151/8f461c60-5fe8-11e6-9196-ca74b3233eb9.png)
