### PR TITLE
Extract tabbedview's allowed attributes in to an interface.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.5.1 (unreleased)
 ------------------
 
+- Extract tabbedview's allowed attributes in to an interface.
+  [phgross]
+
 - Move uploadbox above tabbedview menu
   [Kevin Bieri]
 

--- a/ftw/tabbedview/browser/configure.zcml
+++ b/ftw/tabbedview/browser/configure.zcml
@@ -21,7 +21,7 @@
         name="tabbed_view"
         class=".tabbed.TabbedView"
         permission="zope2.View"
-        allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+        allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
         />
 
     <browser:page

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -1,16 +1,18 @@
-from Products.CMFCore.Expression import getExprContext
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.dictstorage.interfaces import IDictStorage
 from ftw.tabbedview import tabbedviewMessageFactory as _
 from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
 from ftw.tabbedview.interfaces import IGridStateStorageKeyGenerator
+from ftw.tabbedview.interfaces import ITabbedViewEndpoints
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.Expression import getExprContext
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.i18n import translate
+from zope.interface import implements
 import AccessControl
 
 
@@ -29,6 +31,8 @@ except ImportError:
 
 class TabbedView(BrowserView):
     """A View containing tabs with fancy ui"""
+
+    implements(ITabbedViewEndpoints)
 
     __call__ = ViewPageTemplateFile("tabbed.pt")
     macros = __call__.macros

--- a/ftw/tabbedview/interfaces.py
+++ b/ftw/tabbedview/interfaces.py
@@ -40,6 +40,41 @@ class ITabbedView(Interface):
         )
 
 
+class ITabbedViewEndpoints(Interface):
+
+    def listing():
+        """Fetches the corresponding view which renders a listing.
+        Called from javascript tabbedview.js in reload_view.
+        """
+
+    def select_all():
+        """Called when select-all is clicked. Returns HTML containing
+        a hidden input field for each field which is not displayed at
+        the moment.
+        """
+
+    def reorder():
+        """Called when the items in the grid are reordered"""
+
+    def setgridstate():
+        """Stores the current grid configuration (visible columns,
+        column order, grouping, sorting etc.) persistent in dictstorage.
+        """
+
+    def set_default_tab(tab=None, view=None):
+        """Sets the default tab. The id of the tab is passed as
+        argument or in the request payload as ``tab``.
+        """
+
+    def msg_unknownresponse():
+        """Return the message that is rendered when a javascript request gets
+        a response from a different source than a tabbed view.
+
+        This happens when a redirect occurs, for example a redirect to a login
+        form due to a session timeout.
+        """
+
+
 class IListingView(Interface):
     """Marker interface for listing tabs.
     """


### PR DESCRIPTION
This PR extracts all the endpoint names from `allowed_attributes` in to a separate interface. 

This allows to register a customized version of a tabbedview, without copying all the endpoints name in the specific zcml registration.

@jone please have a look 