### PR TITLE
Chameleon support: make macros access lazy.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 3.5.2 (unreleased)
 ------------------
 
+- Chameleon support: make macros access lazy. [jone]
+
 - Check for searchbox value when a tabbedview page gets reloaded.
   [phgross]
 

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -35,7 +35,10 @@ class TabbedView(BrowserView):
     implements(ITabbedViewEndpoints)
 
     __call__ = ViewPageTemplateFile("tabbed.pt")
-    macros = __call__.macros
+
+    @property
+    def macros(self):
+        return __call__.macros
 
     def _resolve_tab(self, name):
         """Resolve the view responsible for a single tab.


### PR DESCRIPTION
Chameleon may, depending on its configuration, compile the ViewPageTemplateFile on first access.
Therefore the macros are not correctly available after instantiation. This can be solved by using a property.

@phgross you've introduced this in #37, not exactly sure why / how it works. Please verify whether your use case still works with macro as property.