### PR TITLE
Fix NameError in tabebdview macros.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix NameError in tabebdview macros. [jone]
 
 
 3.5.2 (2016-09-26)

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -38,7 +38,7 @@ class TabbedView(BrowserView):
 
     @property
     def macros(self):
-        return __call__.macros
+        return self.__call__.macros
 
     def _resolve_tab(self, name):
         """Resolve the view responsible for a single tab.


### PR DESCRIPTION
The issue was introduced in #58 (chameleon support).