### PR TITLE
Fix tabbedview history

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix tabbedview history.
+  [Kevin Bieri]
 
 
 3.5.3 (2016-09-27)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -1,3 +1,29 @@
+function Observer(initialValue) {
+
+  var value = initialValue;
+  var changed = false;
+  var reveal = {};
+
+  function update(newValue) {
+    if(newValue === value) {
+      changed = false;
+    } else {
+      changed = true;
+    }
+    value = newValue;
+  }
+
+  function hasChanged() { return changed; }
+
+  reveal.update = update;
+  reveal.hasChanged = hasChanged;
+
+  return Object.freeze(reveal);
+
+}
+
+var historyObserver = Observer("");
+
 /* find_param function */
 jQuery.find_param = function(s) {
   var r = {};
@@ -336,10 +362,14 @@ load_tabbedview = function(callback) {
      tab reloading as long as we have no location.hash. This condition
      makes using browser-back / -forward work because in this situation
      we have a location.hash. */
-  $('.tabbedview-tabs .formTabs a').bind('history', function(e) {
-    if (!location.hash) {
-      e.preventDefault();
-      e.stopPropagation();
+  $('.tabbedview-tabs .formTabs a').bind('history', function(event, hash) {
+    historyObserver.update(hash);
+    if (!hash) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    if(historyObserver.hasChanged() && !hash) {
+      history.back();
     }
   });
 


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.tabbedview/issues/53

The tabbedview inserts a hash representing the current tab in the URL.
The browser stores this change as an additional history entry beside
the initial URL without any tab selected.
This additional entry where no tab is selected produces a strange behavior
when the user triggers the back button in the browser.
So the fix triggers an additional browser back to skip the additional history entry.
This trigger is only fired when the hash has changed and points to a state
with no tab selected saying no hash in the URL.