### PR TITLE
Minor Chameleon compatibility fixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 3.5.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Template API breakage - renamed slot 'content-title' to 'tabbedview-content-title'
+- [Rotonen]
+
+- Minor Chameleon compatibility fixes.
+  [Rotonen]
 
 
 3.5.4 (2016-10-18)

--- a/ftw/tabbedview/browser/tabbed.pt
+++ b/ftw/tabbedview/browser/tabbed.pt
@@ -43,7 +43,7 @@
           <div tal:replace="structure provider:plone.abovecontenttitle" />
 
 
-          <metal:title define-slot="content-title">
+          <metal:title define-slot="tabbedview-content-title">
             <h1 class="documentFirstHeading" tal:content="context/Title" />
           </metal:title>
           <div tal:replace="structure provider:plone.belowcontenttitle" />

--- a/ftw/tabbedview/configure.zcml
+++ b/ftw/tabbedview/configure.zcml
@@ -5,7 +5,9 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:meta="http://namespaces.zope.org/meta"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:cmf="http://namespaces.zope.org/cmf">
+    xmlns:cmf="http://namespaces.zope.org/cmf"
+    i18n_domain="ftw.tabbedview"
+    >
 
     <meta:provides feature="ftw.tabbedview3" />
 


### PR DESCRIPTION
* Add the i18n namespace to configure.zcml
  * This silences ftw.tabbedview related Chameleon warnings
* Rename the title slot of the view to `tabbedview-content-title`

Fixes #61