### PR TITLE
Fix default tab for HTTPS.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix default tab for HTTPS. [jone]
 
 
 3.6.0 (2016-12-06)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -345,7 +345,7 @@ load_tabbedview = function(callback) {
 
 
   var initialIndex = 0;
-  var initial = $('.formTab > .initial');
+  var initial = $('.formTab .initial');
   if (initial.length > 0) {
     initialIndex = initial.parents(':first').index();
   }


### PR DESCRIPTION
When the page is served over HTTPS and the mark_special_links.js is enabled, the tab links are wrapped into a `<span class="link-https>`. This breaks a too specific CSS selector. By not dependning on the nesting in the selector we can awoid this problem.

// CC @deiferni you will need that 😜 