### PR TITLE
Fix default tab for HTTPS.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix default tab for HTTPS. [mbaechtold]
 
 
 3.6.1 (2017-03-01)

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -347,7 +347,7 @@ load_tabbedview = function(callback) {
   var initialIndex = 0;
   var initial = $('.formTab .initial');
   if (initial.length > 0) {
-    initialIndex = initial.parents(':first').index();
+    initialIndex = initial.parents('li:first').index();
   }
 
   /* When a default-tab is configured and we load the tabbedview,


### PR DESCRIPTION
The bugfix release 3.6.1 is incomplete without this change.