### PR TITLE
Implement p.a.caching etag value adapter.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,38 @@ Screenshot of the same listing using the ``extjs`` table implementation:
 .. image:: https://github.com/4teamwork/ftw.tabbedview/raw/master/docs/screenshot2.png
 
 
+Caching
+=======
+
+``ftw.tabbedview`` provides a ``plone.app.caching`` etag adapter
+named ``tabbedview``.
+This etag can be used in the caching configuration in order to make the cache
+flush when changing the default tab.
+
+In order to enable this, you need to add it to your caching configuration.
+Depending on how you want to set up caching in your project, you may want
+to add the etag to your rulesets.
+You can do that in a ``registry.xml``:
+
+.. code:: xml
+
+    <?xml version="1.0"?>
+    <registry>
+
+        <record name="plone.app.caching.weakCaching.plone.content.itemView.etags">
+            <value purge="False">
+                <element>tabbedview</element>
+            </value>
+        </record>
+
+        <record name="plone.app.caching.weakCaching.plone.content.folderView.etags">
+            <value purge="False">
+                <element>tabbedview</element>
+            </value>
+        </record>
+
+    </registry>
+
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 3.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add plone.app.caching etag value adapter containing the users default tab.
+  In order to benefit from that, you need to update your caching configuration.
+  See the readme for instructions. [jone]
 
 
 3.6.2 (2017-03-02)

--- a/ftw/tabbedview/caching.py
+++ b/ftw/tabbedview/caching.py
@@ -1,0 +1,24 @@
+from ftw.dictstorage.interfaces import IDictStorage
+from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
+from plone.app.caching.interfaces import IETagValue
+from plone.app.caching.operations.utils import getContext
+from zope.component import adapts
+from zope.component import getMultiAdapter
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class TabbedviewETagValue(object):
+    implements(IETagValue)
+    adapts(Interface, Interface)
+
+    def __init__(self, published, request):
+        self.published = published
+        self.request = request
+
+    def __call__(self):
+        storage_key_generator = getMultiAdapter(
+            (getContext(self.published), self.published, self.request),
+            IDefaultTabStorageKeyGenerator)
+        storage_key = storage_key_generator.get_key()
+        return IDictStorage(self.published).get(storage_key) or ''

--- a/ftw/tabbedview/configure.zcml
+++ b/ftw/tabbedview/configure.zcml
@@ -41,6 +41,8 @@
     <adapter factory=".statestorage.DefaultDictStorage" />
     <adapter factory=".defaulttab.DefaultTabStorageKeyGenerator" />
 
+    <adapter factory=".caching.TabbedviewETagValue" name="tabbedview" />
+
     <!-- Register the import_various step -->
     <genericsetup:importStep
         name="ftw.tabbedview.various"

--- a/ftw/tabbedview/tests/test_caching.py
+++ b/ftw/tabbedview/tests/test_caching.py
@@ -1,0 +1,24 @@
+from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
+from plone.app.caching.interfaces import IETagValue
+from unittest2 import TestCase
+from zope.component import getMultiAdapter
+
+
+class TestETagValue(TestCase):
+    layer = TABBEDVIEW_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def test_etag_value_returns_default_tab(self):
+        tabbed_view = self.portal.unrestrictedTraverse('@@tabbed_view')
+        self.assertEquals('', self.get_etag_value_for(tabbed_view))
+        tabbed_view.set_default_tab('documents')
+        self.assertEquals('documents', self.get_etag_value_for(tabbed_view))
+
+    def get_etag_value_for(self, view):
+        adapter = getMultiAdapter((view, self.request),
+                                  IETagValue,
+                                  name='tabbedview')
+        return adapter()


### PR DESCRIPTION
The new plone.app.caching etag value adapter named ``tabbedview`` provides the current default tab of the user.
This is important for the cache to flush whenever the user selects a new default tab.

``ftw.tabbedview`` does not enable the etag value.
The integrator needs to do that by adding the ``tabbedview`` etag to the ruleset configuration.
See the readme for instructions.