### PR TITLE
Fix error when calculating etag value on non-tabbedview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error when calculating etag value on non-tabbedview. [jone]
 
 
 3.7.0 (2017-03-02)

--- a/ftw/tabbedview/caching.py
+++ b/ftw/tabbedview/caching.py
@@ -3,7 +3,7 @@ from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
 from plone.app.caching.interfaces import IETagValue
 from plone.app.caching.operations.utils import getContext
 from zope.component import adapts
-from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -17,8 +17,11 @@ class TabbedviewETagValue(object):
         self.request = request
 
     def __call__(self):
-        storage_key_generator = getMultiAdapter(
+        storage_key_generator = queryMultiAdapter(
             (getContext(self.published), self.published, self.request),
             IDefaultTabStorageKeyGenerator)
+        if storage_key_generator is None:
+            return ''
+
         storage_key = storage_key_generator.get_key()
         return IDictStorage(self.published).get(storage_key) or ''

--- a/ftw/tabbedview/tests/test_caching.py
+++ b/ftw/tabbedview/tests/test_caching.py
@@ -17,6 +17,10 @@ class TestETagValue(TestCase):
         tabbed_view.set_default_tab('documents')
         self.assertEquals('documents', self.get_etag_value_for(tabbed_view))
 
+    def test_default_value_is_empty_string(self):
+        view = self.portal.unrestrictedTraverse('@@view')
+        self.assertEquals('', self.get_etag_value_for(view))
+
     def get_etag_value_for(self, view):
         adapter = getMultiAdapter((view, self.request),
                                   IETagValue,


### PR DESCRIPTION
The ETagValue adapter must always return a string.

@Rotonen You have noticed `None` beeing returned as etag value, but I believe that this is not possible because of the only return statement:
```python
return IDictStorage(self.published).get(storage_key) or ''
```
Whenever it would be `None`, it would return an empty string.

But I have found an error when not accessing a tabbed view:
```python
Error in test test_default_value_is_empty_string (ftw.tabbedview.tests.test_caching.TestETagValue)
Traceback (most recent call last):
....
  File "/Users/jone/projects/packages/ftw.tabbedview/ftw/tabbedview/tests/test_caching.py", line 28, in get_etag_value_for
    return adapter()
  File "/Users/jone/projects/packages/ftw.tabbedview/ftw/tabbedview/caching.py", line 26, in __call__
    storage_key = storage_key_generator.get_key()
AttributeError: 'NoneType' object has no attribute 'get_key'
```

I belive that this error may have been catched and `None` was returned.
This change fixes this issue.

(//cc @deiferni @lukasgraf as discussed)