### PR TITLE
Fix etag / defaulttab generation for anonymous users.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix cachekey / defaulttab generation for anonymous users. [jone]
 
 
 3.7.1 (2017-03-13)

--- a/ftw/tabbedview/defaulttab.py
+++ b/ftw/tabbedview/defaulttab.py
@@ -26,5 +26,5 @@ class DefaultTabStorageKeyGenerator(object):
             'defaulttab',
             self.context.portal_type,
             self.view.__name__,
-            user.getId()]
+            user.getId() or '']
         return '-'.join(parts)

--- a/ftw/tabbedview/tests/test_caching.py
+++ b/ftw/tabbedview/tests/test_caching.py
@@ -1,5 +1,6 @@
 from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
 from plone.app.caching.interfaces import IETagValue
+from plone.app.testing import logout
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
 
@@ -20,6 +21,11 @@ class TestETagValue(TestCase):
     def test_default_value_is_empty_string(self):
         view = self.portal.unrestrictedTraverse('@@view')
         self.assertEquals('', self.get_etag_value_for(view))
+
+    def test_default_value_is_empty_string_for_anonymous(self):
+        logout()
+        tabbed_view = self.portal.unrestrictedTraverse('@@tabbed_view')
+        self.assertEquals('', self.get_etag_value_for(tabbed_view))
 
     def get_etag_value_for(self, view):
         adapter = getMultiAdapter((view, self.request),


### PR DESCRIPTION
When creating the defaulttab key for anomyous users it crashed.
This is used for generating the etag value, which may be done for anoymous users now and then.

Fixes #68 
