### PR TITLE
Add support for Plone 5.1

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Plone 5.1 [njohner]
 
 
 4.0.0 (2018-01-24)

--- a/ftw/tabbedview/browser/tabbed.py
+++ b/ftw/tabbedview/browser/tabbed.py
@@ -126,7 +126,6 @@ class TabbedView(BrowserView):
         """
         context = self.context
         types_tool = getToolByName(context, 'portal_types')
-        ai_tool = getToolByName(context, 'portal_actionicons')
         actions = types_tool.listActions(object=context)
         plone_state = queryMultiAdapter((self.context, self.request),
                                         name='plone_portal_state')
@@ -143,9 +142,7 @@ class TabbedView(BrowserView):
                 continue
 
             if action.category == category:
-                icon = ai_tool.queryActionIcon(action_id=action.id,
-                                                category=category,
-                                                context=context)
+                icon = None
                 econtext = getExprContext(context, context)
                 action = action.getAction(ec=econtext)
 

--- a/ftw/tabbedview/testing.py
+++ b/ftw/tabbedview/testing.py
@@ -1,3 +1,6 @@
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from ftw.testing.layer import ComponentRegistryLayer
 from pkg_resources import get_distribution
 from plone.app.testing import applyProfile
@@ -5,13 +8,13 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from z3c.autoinclude.api import disable_dependencies
 from z3c.autoinclude.api import disable_plugins
 from zope.configuration import xmlconfig
 
 
 IS_PLONE_5 = get_distribution('Plone').version >= '5'
+
 
 class ZCMLLayer(ComponentRegistryLayer):
     """Loads the zcml of ftw.tabbedview and dependencies.
@@ -35,7 +38,7 @@ ZCML_LAYER = ZCMLLayer()
 
 class TabbedViewLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         xmlconfig.string(
@@ -60,8 +63,10 @@ class TabbedViewLayer(PloneSandboxLayer):
         if IS_PLONE_5:
             applyProfile(portal, 'plone.app.contenttypes:default')
 
+
 TABBED_VIEW_LAYER = TabbedViewLayer()
 TABBEDVIEW_INTEGRATION_TESTING = IntegrationTesting(
     bases=(TABBED_VIEW_LAYER, ), name="ftw.tabbedview:integration")
 TABBEDVIEW_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(TABBED_VIEW_LAYER, ), name="ftw.tabbedview:functional")
+    bases=(TABBED_VIEW_LAYER, set_builder_session_factory(functional_session_factory)),
+    name="ftw.tabbedview:functional")

--- a/ftw/tabbedview/testing.py
+++ b/ftw/tabbedview/testing.py
@@ -1,4 +1,6 @@
 from ftw.testing.layer import ComponentRegistryLayer
+from pkg_resources import get_distribution
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -8,6 +10,8 @@ from z3c.autoinclude.api import disable_dependencies
 from z3c.autoinclude.api import disable_plugins
 from zope.configuration import xmlconfig
 
+
+IS_PLONE_5 = get_distribution('Plone').version >= '5'
 
 class ZCMLLayer(ComponentRegistryLayer):
     """Loads the zcml of ftw.tabbedview and dependencies.
@@ -53,7 +57,8 @@ class TabbedViewLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.tabbedview:default')
         applyProfile(portal, 'ftw.tabbedview.tests:tabs')
-
+        if IS_PLONE_5:
+            applyProfile(portal, 'plone.app.contenttypes:default')
 
 TABBED_VIEW_LAYER = TabbedViewLayer()
 TABBEDVIEW_INTEGRATION_TESTING = IntegrationTesting(

--- a/ftw/tabbedview/tests/test_batch_import.py
+++ b/ftw/tabbedview/tests/test_batch_import.py
@@ -6,7 +6,7 @@ from pkg_resources import get_distribution
 class TestBatchImport(TestCase):
 
     def test_import(self):
-        if get_distribution('Products.CMFPlone').version.startswith('4.3'):
+        if float(get_distribution('Products.CMFPlone').version[:3]) >= 4.3:
             # plone.batching
             self.assertEquals(batch_method.__name__, 'fromPagenumber')
         else:

--- a/ftw/tabbedview/tests/test_caching.py
+++ b/ftw/tabbedview/tests/test_caching.py
@@ -1,6 +1,12 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
 from plone.app.caching.interfaces import IETagValue
+from plone.app.testing import login
 from plone.app.testing import logout
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
 
@@ -19,7 +25,10 @@ class TestETagValue(TestCase):
         self.assertEquals('documents', self.get_etag_value_for(tabbed_view))
 
     def test_default_value_is_empty_string(self):
-        view = self.portal.unrestrictedTraverse('@@view')
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+        folder = create(Builder("folder"))
+        view = folder.unrestrictedTraverse('@@view')
         self.assertEquals('', self.get_etag_value_for(view))
 
     def test_default_value_is_empty_string_for_anonymous(self):

--- a/ftw/tabbedview/tests/test_load_package.py
+++ b/ftw/tabbedview/tests/test_load_package.py
@@ -1,7 +1,6 @@
 from ftw.dictstorage.interfaces import IDictStorage
 from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
 from ftw.tabbedview.testing import TABBEDVIEW_INTEGRATION_TESTING
-from Products.CMFCore.utils import getToolByName
 from pyquery import PyQuery as pq
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
@@ -11,12 +10,6 @@ from zope.component import queryMultiAdapter
 class TestWWWInstallation(TestCase):
 
     layer = TABBEDVIEW_INTEGRATION_TESTING
-
-    def test_css_registered(self):
-        portal = self.layer['portal']
-        csstool = getToolByName(portal, 'portal_css')
-        self.assertTrue(csstool.getResource(
-            '++resource++ftw.tabbedview-resources/tabbedview.css'))
 
     def test_initial_tab_is_reseted_on_every_request(self):
         portal = self.layer['portal']

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'pyquery',
     'ftw.testbrowser',
     'ftw.testing',
+    'ftw.builder',
     ]
 
 extras_require = {
@@ -33,6 +34,7 @@ setup(name='ftw.tabbedview',
         'Framework :: Plone',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
@@ -55,6 +57,7 @@ setup(name='ftw.tabbedview',
         'ftw.table>=1.19.0',
         'collective.js.throttledebounce',
         'plone.api',
+        'plone.app.jquerytools',
         'plone.app.registry',
         'ftw.dictstorage',
         'ftw.upgrade',

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,7 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+    sources.cfg
+    versions.cfg
+
+package-name = ftw.tabbedview


### PR DESCRIPTION
* Dropped icons for actions in `TabbedView`
* `get_etag_value_for` raises an exception on the portal root due to a new implementation of `plone.app.caching.operations.utils.getContext`