### PR TITLE
Use classes instead of ids for batching-template to prevent duplicated ids

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 3.8.4 (unreleased)
 ------------------
 
+- Use classes instead ids for batching-template to prevent duplicated ids [elioschmutz]
+
 - Load the tabbedview itself async. [Rotonen]
 
 

--- a/ftw/tabbedview/browser/batching.pt
+++ b/ftw/tabbedview/browser/batching.pt
@@ -63,11 +63,11 @@
     </span>
 
     <!-- dynamic batching -->
-    <form tal:condition="view/dynamic_batchsize_enabled" id="dynamic_batching_form"
-          i18n:domain="ftw.tabbedview">
+    <div tal:condition="view/dynamic_batchsize_enabled" class="dynamicBatchSizeContainer" i18n:domain="ftw.tabbedview">
       <span i18n:translate="">Lines per page:</span>
-      <input id="tabbedview-batchbox" name="tabbedview-batchbox"
+      <input class="tabbedviewBatchbox"
              type="text"
              tal:attributes="value batch/pagesize" />
-    </form>
+    </div>
+
 </div>

--- a/ftw/tabbedview/browser/resources/tabbedview.css
+++ b/ftw/tabbedview/browser/resources/tabbedview.css
@@ -1,9 +1,9 @@
-#dynamic_batching_form {
+.dynamicBatchSizeContainer {
   display: inline;
   margin-left: 1em;
 }
 
-#tabbedview-batchbox {
+.tabbedviewBatchbox {
   width: 3em;
 }
 

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -307,6 +307,12 @@ load_tabbedview = function(callback) {
       }
 
       tabbedview.view_container.trigger('tab-menu-updated');
+    },
+
+    reset_pagesize: function(pageSize) {
+      tabbedview.param('pagesize', pageSize);
+      tabbedview.flush_params('pagenumber:int');
+      tabbedview.reload_view();
     }
 
   };
@@ -483,21 +489,19 @@ load_tabbedview = function(callback) {
     tabbedview.reload_view();
   });
 
-  // dynamic batching functionality
-  $('#tabbedview-batchbox').live('blur', function() {
-    $('#dynamic_batching_form').submit();
-  });
-
-  // workaround to bind the submit event with live
-  $('body').each(function(){
-    $('#dynamic_batching_form').live('submit', function(event){
-      tabbedview.param(
-        'pagesize', $('#tabbedview-batchbox').val());
-      tabbedview.flush_params('pagenumber:int');
-      tabbedview.reload_view();
-      event.preventDefault();
-    });
-  });
+  $('.tabbedviewBatchbox').live(
+    {
+      blur: function(e) {
+        tabbedview.reset_pagesize($(e.target).val());
+      },
+      keypress: function(e) {
+        if(e.which === 13){  // Enter
+          event.preventDefault();
+          tabbedview.reset_pagesize($(e.target).val());
+        }
+      }
+    }
+  );
 
   tabbedview.view_container.bind('reload', function() {
     //hide or show filter box


### PR DESCRIPTION
The batching-container is sometimes used multiple times but the container defines some html-ids.

This markup will render inavalid html due to duplicated ids in the markup.

This PR
- replaces the IDs with classes for the batching-container
- removes the form tag for the `dynamicBatchingForm` because this prevents us from putting the batching-container within a form (nested forms are not allowed)

Issuer: https://github.com/4teamwork/opengever.core/pull/3217