### PR TITLE
Fix filter for IE when using `clear field` button

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
+- Fix filter for IE when using `clear field` button. [Kevin Bieri]
 - Add support for Plone 5.1 [njohner]
 
 

--- a/ftw/tabbedview/browser/resources/tabbedview.js
+++ b/ftw/tabbedview/browser/resources/tabbedview.js
@@ -438,7 +438,7 @@ load_tabbedview = function(callback) {
 
   $('.tabbedview-tabs .ui-tabs-nav a').removeAttr('title');
 
-  tabbedview.searchbox.bind("keyup", $.debounce(250, function(e) {
+  tabbedview.searchbox.bind("input", $.debounce(250, function(e) {
     var value = tabbedview.searchbox.val();
     var previous_value = tabbedview.prop('searchable_text');
     if (value === tabbedview.searchbox.attr('title')) {


### PR DESCRIPTION
Closes https://basecamp.com/2768704/projects/12554551/todos/342458887

The event `keyup` is not triggered when using Internet Explorer's clear
field button next to the input element.
So use the `input` event which is triggered when the value of an input
element is changed -> https://developer.mozilla.org/en-US/docs/Web/Events/input.

According to https://caniuse.com/#feat=input-event the `input` event is working for all common Browsers and IE>=10.