### PR TITLE
Fix bug which caused unsortable columns to be sortable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 3.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix bug which caused unsortable columns to be sortable after storing grid state. [jone]
 
 3.8.3 (2017-08-02)
 ------------------

--- a/ftw/tabbedview/browser/listing.py
+++ b/ftw/tabbedview/browser/listing.py
@@ -484,7 +484,7 @@ class ListingView(BrowserView, BaseTableSourceConfig):
 
                 col_state = column_state_by_id[name]
                 if 'sortable' not in col_state:
-                    col_state['sortable'] = True
+                    col_state['sortable'] = column.get('sortable', True)
 
             state = json.dumps(parsed_state)
 


### PR DESCRIPTION
When reading from a grid state, the sortable flag was set to "True" when the grid state did not contain the sortable flag for a column.

This is a wrong assumption since the column may be configured to be not sortable.

The fix is to use the sortable flag of the column definition with a fallback to "True" when the sortable flag is not defined on the column definition.