### PR TITLE
Also show item count for "all" selection in French.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Also show item count for "all" selection in French. [njohner]
 
 
 4.1.2 (2018-10-24)

--- a/ftw/tabbedview/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/ftw/tabbedview/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -52,7 +52,7 @@ msgstr "Titre"
 
 #: ./ftw/tabbedview/browser/selection.pt:11
 msgid "all (${amount})"
-msgstr "Tous"
+msgstr "Tous (${amount})"
 
 #. Default: "More actions"
 #: ./ftw/tabbedview/browser/menu.pt:14


### PR DESCRIPTION
The item count was missing in the French translation of the `all` selection button, see the German vs French version below. This is now fixed.

**German has the count**
<img width="584" alt="Screenshot 2019-08-07 at 16 20 20" src="https://user-images.githubusercontent.com/7374243/62630558-750e8c80-b92f-11e9-9e7f-8e3ca45fc4fb.png">

**French does not**
<img width="703" alt="Screenshot 2019-08-07 at 16 20 29" src="https://user-images.githubusercontent.com/7374243/62630559-750e8c80-b92f-11e9-8aae-51169dc9b2bd.png">

**French after this update**
<img width="548" alt="Screenshot 2019-08-07 at 16 24 18" src="https://user-images.githubusercontent.com/7374243/62630834-f8c87900-b92f-11e9-897c-8ade4095b4e8.png">


This is for https://github.com/4teamwork/opengever.core/issues/5690