### PR TITLE
Fix tests / drop Plone 4.2 support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-4.1.4 (unreleased)
+4.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop Plone 4.2 support. [jone]
 
 
 4.1.3 (2019-08-08)

--- a/ftw/tabbedview/tests/test_batch_import.py
+++ b/ftw/tabbedview/tests/test_batch_import.py
@@ -1,4 +1,4 @@
-from unittest2 import TestCase
+from unittest import TestCase
 from ftw.tabbedview.browser.listing import batch_method
 from pkg_resources import get_distribution
 

--- a/ftw/tabbedview/tests/test_caching.py
+++ b/ftw/tabbedview/tests/test_caching.py
@@ -7,7 +7,7 @@ from plone.app.testing import logout
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getMultiAdapter
 
 

--- a/ftw/tabbedview/tests/test_config_view.py
+++ b/ftw/tabbedview/tests/test_config_view.py
@@ -22,22 +22,18 @@ class TestTabbedviewConfigView(MockTestCase):
 
         self.context = self.stub()
         self.request = self.stub_request()
-        self.expect(self.request.get('PUBLISHED', None)).result(None)
+        self.request.get('PUBLISHED', None).return_value = None
 
     def tearDown(self):
         super(TestTabbedviewConfigView, self).tearDown()
         newSecurityManager(None, nobody)
 
     def test_component_registered(self):
-        self.replay()
-
         view = queryMultiAdapter((self.context, self.request),
                                  name='tabbedview_config')
         self.assertNotEqual(view, None)
 
     def test_extjs_disabled_by_default(self):
-        self.replay()
-
         view = queryMultiAdapter((self.context, self.request),
                                  name='tabbedview_config')
         self.assertEqual(view.extjs_enabled(), False)
@@ -45,8 +41,6 @@ class TestTabbedviewConfigView(MockTestCase):
     def test_extjs_enabled(self):
         key = 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled'
         self.registry[key] = True
-
-        self.replay()
 
         newSecurityManager(None, system)
         view = queryMultiAdapter((self.context, self.request),
@@ -56,8 +50,6 @@ class TestTabbedviewConfigView(MockTestCase):
     def test_extjs_anonymous_disabled(self):
         key = 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled'
         self.registry[key] = True
-
-        self.replay()
 
         newSecurityManager(None, nobody)
         view = queryMultiAdapter((self.context, self.request),

--- a/ftw/tabbedview/tests/test_fallback.py
+++ b/ftw/tabbedview/tests/test_fallback.py
@@ -1,9 +1,9 @@
 from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
-from ftw.testing import MockTestCase
+from unittest import TestCase
 
 
-class TestFallBackView(MockTestCase):
+class TestFallBackView(TestCase):
 
     layer = TABBEDVIEW_FUNCTIONAL_TESTING
 

--- a/ftw/tabbedview/tests/test_load_package.py
+++ b/ftw/tabbedview/tests/test_load_package.py
@@ -2,7 +2,7 @@ from ftw.dictstorage.interfaces import IDictStorage
 from ftw.tabbedview.interfaces import IDefaultTabStorageKeyGenerator
 from ftw.tabbedview.testing import TABBEDVIEW_INTEGRATION_TESTING
 from pyquery import PyQuery as pq
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 

--- a/ftw/tabbedview/tests/test_statestorage.py
+++ b/ftw/tabbedview/tests/test_statestorage.py
@@ -1,4 +1,5 @@
 from ftw.dictstorage.interfaces import IConfig
+from mock import Mock
 from ftw.dictstorage.interfaces import IDictStorage
 from ftw.tabbedview import statestorage
 from ftw.tabbedview.interfaces import IDefaultDictStorageConfig
@@ -54,8 +55,6 @@ class TestDefaultDictStorageConfig(MockTestCase):
 
     def test_component_registered(self):
         context = self.providing_stub(IBrowserView)
-
-        self.replay()
         component = getAdapter(context, IConfig)
         self.assertEqual(type(component),
                          statestorage.DefaultDictStorageConfig)
@@ -77,20 +76,16 @@ class TestDefaultDictStorageConfig(MockTestCase):
     def test_get_annotated_object_is_plone_site(self):
         site = self.create_dummy()
 
-        portal_url = self.mocker.mock()
+        portal_url = Mock()
         self.mock_tool(portal_url, 'portal_url')
-        self.expect(portal_url.getPortalObject()).result(site)
+        portal_url.getPortalObject.return_value = site
 
         context = self.providing_stub(IBrowserView)
-
-        self.replay()
         component = getAdapter(context, IConfig)
         self.assertEqual(component.get_annotated_object(), site)
 
     def test_get_annotations_key(self):
         context = self.providing_stub(IBrowserView)
-
-        self.replay()
         component = getAdapter(context, IConfig)
         self.assertEqual(component.get_annotations_key(),
                          'ftw.dictstorage-data')
@@ -103,8 +98,6 @@ class TestDefaultDictStorage(MockTestCase):
     def test_component_registered(self):
         context = self.providing_stub(IBrowserView)
         config = self.providing_stub(IDefaultDictStorageConfig)
-
-        self.replay()
         component = getMultiAdapter((context, config), IDictStorage)
         self.assertEqual(type(component), statestorage.DefaultDictStorage)
 
@@ -120,11 +113,8 @@ class TestDefaultDictStorage(MockTestCase):
         context = self.providing_stub(IBrowserView)
         config = self.providing_stub(IDefaultDictStorageConfig)
 
-        self.expect(config.get_annotated_object()).result(site)
-        self.expect(config.get_annotations_key()).result(
-            'ftw.dictstorage-data')
-
-        self.replay()
+        config.get_annotated_object.return_value = site
+        config.get_annotations_key.return_value = 'ftw.dictstorage-data'
         component = getMultiAdapter((context, config), IDictStorage)
 
         self.assertEqual(type(component.storage), PersistentMapping)

--- a/ftw/tabbedview/tests/test_statestorage.py
+++ b/ftw/tabbedview/tests/test_statestorage.py
@@ -7,7 +7,7 @@ from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
 from ftw.tabbedview.testing import ZCML_LAYER
 from ftw.testing import MockTestCase
 from persistent.mapping import PersistentMapping
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.annotation import IAttributeAnnotatable
 from zope.component import getAdapter
 from zope.component import getMultiAdapter

--- a/ftw/tabbedview/tests/test_tabbed_view.py
+++ b/ftw/tabbedview/tests/test_tabbed_view.py
@@ -2,7 +2,7 @@ from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '4.1.4.dev0'
+version = '4.2.0.dev0'
 maintainer = 'Jonas Baumann'
 
 tests_require = [
@@ -32,7 +32,6 @@ setup(name='ftw.tabbedview',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.1',
         'Programming Language :: Python',

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -2,6 +2,5 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
     sources.cfg
-    versions.cfg
 
 package-name = ftw.tabbedview

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-
-package-name = ftw.tabbedview

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -2,6 +2,5 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     sources.cfg
-    versions.cfg
 
 package-name = ftw.tabbedview

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -2,6 +2,5 @@
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
     sources.cfg
-    versions.cfg
 
 package-name = ftw.tabbedview

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,4 +1,0 @@
-[versions]
-# zope.testrunner 4.4.5 has changed the testing layer ordering
-# which causes test isolation problems with the ZCML layer.
-zope.testrunner = 4.4.4


### PR DESCRIPTION
- Drop Plone 4.2 support; tests are no longer passing.
- Use `unittest` instead of `unittest2`.
- Fix wrong base class (`MockTestCase` was used but it was not a mock test).
- Make `ftw.testing>2` compatible by updating all mock tests.
- Remove old version pinnings - no longer needed.