### PR TITLE
Fix "instancemethod not iterable" for empty action lists

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug where empty action lists would cause a failure to render the tab. [lgraf]
 
 
 4.2.0 (2019-11-26)

--- a/ftw/tabbedview/browser/listing.py
+++ b/ftw/tabbedview/browser/listing.py
@@ -310,10 +310,11 @@ class ListingView(BrowserView, BaseTableSourceConfig):
         are listed in a drop-down.
         This symbol may be a list (not callable) for easier handling.
         """
-        if callable(self.enabled_actions):
-            return list(self.enabled_actions())
-        else:
-            return list(self.enabled_actions)
+        enabled = self.enabled_actions
+        if callable(enabled):
+            enabled = enabled()
+
+        return list(enabled)
 
     def minor_actions(self):
         """ Returns a list of auto-generated minor action ids.
@@ -321,17 +322,24 @@ class ListingView(BrowserView, BaseTableSourceConfig):
         major actions.
         """
         major = self.major_actions
-        major = callable(major) and list(major()) or list(major)
+        if callable(major):
+            major = major()
+        major = list(major)
+
         enabled = self.enabled_actions
-        enabled = callable(enabled) and list(enabled()) or list(enabled)
+        if callable(enabled):
+            enabled = enabled()
+        enabled = list(enabled)
+
         return list(filter(lambda a: a not in major, enabled))
 
     @instance.memoize
     def buttons(self):
-        if callable(self.enabled_actions):
-            enabled_actions = list(self.enabled_actions())
-        else:
-            enabled_actions = list(self.enabled_actions)
+        enabled = self.enabled_actions
+        if callable(enabled):
+            enabled = enabled()
+        enabled = list(enabled)
+
         buttons = []
         context = aq_inner(self.context)
         portal_actions = getToolByName(context, 'portal_actions')
@@ -351,7 +359,7 @@ class ListingView(BrowserView, BaseTableSourceConfig):
         for button in button_actions:
             # Make proper classes for our buttons
             if button['id'] != 'paste' or context.cb_dataValid():
-                if button['id'] in enabled_actions:
+                if button['id'] in enabled:
                     buttons.append(self.setbuttonclass(button))
         return list(buttons)
 
@@ -359,7 +367,9 @@ class ListingView(BrowserView, BaseTableSourceConfig):
         """ All buttons, which are listed in self.major_actions
         """
         major = self.major_actions
-        major = callable(major) and list(major()) or list(major)
+        if callable(major):
+            major = major()
+        major = list(major)
         return filter(lambda b: b['id'] in major, self.buttons())
 
     def minor_buttons(self):

--- a/ftw/tabbedview/tests/profiles/tabs/types/Plone_Site.xml
+++ b/ftw/tabbedview/tests/profiles/tabs/types/Plone_Site.xml
@@ -24,5 +24,12 @@
           url_expr="string:#"
           visible="True">
   </action>
+  <action title="Sample Listing Tab"
+          action_id="samplelisting"
+          category="tabbedview-tabs"
+          condition_expr=""
+          url_expr="string:#"
+          visible="True">
+  </action>
 
 </object>

--- a/ftw/tabbedview/tests/tabs.py
+++ b/ftw/tabbedview/tests/tabs.py
@@ -1,3 +1,4 @@
+from ftw.tabbedview.browser.listing import CatalogListingView
 from ftw.tabbedview.browser.listing import ListingView
 
 
@@ -12,4 +13,8 @@ class SomeOtherTab(ListingView):
 
 
 class RestrictedTab(ListingView):
+    pass
+
+
+class SampleCatalogListingTab(CatalogListingView):
     pass

--- a/ftw/tabbedview/tests/tabs.zcml
+++ b/ftw/tabbedview/tests/tabs.zcml
@@ -29,4 +29,11 @@
         permission="cmf.ModifyPortalContent"
         />
 
+    <browser:page
+        for="*"
+        name="tabbedview_view-samplecataloglisting"
+        class=".tabs.SampleCatalogListingTab"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/ftw/tabbedview/tests/test_listing.py
+++ b/ftw/tabbedview/tests/test_listing.py
@@ -1,0 +1,60 @@
+from ftw.tabbedview.testing import IS_PLONE_5
+from ftw.tabbedview.testing import TABBEDVIEW_FUNCTIONAL_TESTING
+from Products.CMFPlone.utils import getToolByName
+from unittest import TestCase
+
+
+class TestListingView(TestCase):
+    """This test case by no means covers all of ListingView.
+
+    It was simply written as a regression test when fixing a bug for
+    empty action lists.
+    """
+
+    layer = TABBEDVIEW_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.ai_tool = getToolByName(self.portal, 'portal_actions')
+
+    def get_tab(self):
+        tabbed_view = self.portal.restrictedTraverse('tabbed_view')
+        tab = tabbed_view._resolve_tab('samplecataloglisting')
+        return tab
+
+    def deactivate_all_folder_buttons_actions(self):
+        if IS_PLONE_5:
+            return
+
+        category = self.ai_tool['folder_buttons']
+        for action in category.objectValues():
+            action.visible = False
+
+    def test_major_actions_doesnt_fail_for_empty_list(self):
+        tab = self.get_tab()
+        self.deactivate_all_folder_buttons_actions()
+        major_actions = tab.major_actions()
+
+        self.assertItemsEqual([], major_actions)
+
+    def test_minor_actions_doesnt_fail_for_empty_list(self):
+        tab = self.get_tab()
+        self.deactivate_all_folder_buttons_actions()
+        minor_actions = tab.minor_actions()
+
+        self.assertEqual([], minor_actions)
+
+    def test_major_buttons_doesnt_fail_for_empty_list(self):
+        tab = self.get_tab()
+        self.deactivate_all_folder_buttons_actions()
+        major_buttons = tab.major_buttons()
+
+        self.assertEqual([], major_buttons)
+
+    def test_minor_buttons_doesnt_fail_for_empty_list(self):
+        tab = self.get_tab()
+        self.deactivate_all_folder_buttons_actions()
+        minor_buttons = tab.minor_buttons()
+
+        self.assertEqual([], minor_buttons)


### PR DESCRIPTION
Fix `TypeError: 'instancemethod' object is not iterable` for empty action lists in `ListingView`:

Several of the `major_actions` and `minor_actions` methods in `listing.py` used the **and-or trick** incorrectly to emulate a ternary expression (`x if C else y`), like this:

```
actions = callable(actions) and list(actions()) or actions()
```

This lead to situations where, if the action list was implemented as a method (was callable), and the list was empty, the rightmost part of the expression would be evaluated, because of the falsy value of the empty list. _(Also see [examples in Sentry](https://sentry.4teamwork.ch/organizations/sentry/issues/69257/?project=17))_

This lead to `TypeError: 'instancemethod' object is not iterable`, causing the entire tab to break.

I deliberately chose to *not* use a ternary expression, but instead make it more explicit (and readably, IMHO) what's being done.

I also updated the other places this same pattern is used to be in the same style, even though some places already did it correctly some other way.

